### PR TITLE
Add empty states and stub tables/modals for network and storage mappings pages

### DIFF
--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -15,52 +15,59 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { INetworkMapping } from '../types';
 import MappingsTable from '../components/MappingsTable';
+import AddEditMappingModal from '../components/AddEditMappingModal';
 
 // TODO replace these with real state e.g. from redux
 const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
 const networkMappings: INetworkMapping[] = [];
 
-const NetworkMappingsPage: React.FunctionComponent = () => (
-  <>
-    <PageSection variant="light">
-      <Title headingLevel="h1" size="lg">
-        Network mappings
-      </Title>
-    </PageSection>
-    <PageSection>
-      {isFetchingInitialNetworkMappings ? (
-        <Bullseye>
-          <EmptyState>
-            <div className="pf-c-empty-state__icon">
-              <Spinner size="xl" />
-            </div>
-            <Title headingLevel="h2">Loading...</Title>
-          </EmptyState>
-        </Bullseye>
-      ) : (
-        <Card>
-          <CardBody>
-            {!networkMappings ? null : networkMappings.length === 0 ? (
-              <EmptyState className={spacing.my_2xl}>
-                <EmptyStateIcon icon={PlusCircleIcon} />
-                <Title headingLevel="h2" size="lg">
-                  No network mappings
-                </Title>
-                <EmptyStateBody>
-                  Map source provider networks to target provider networks.
-                </EmptyStateBody>
-                <Button onClick={() => alert('TODO')} variant="primary">
-                  Create mapping
-                </Button>
-              </EmptyState>
-            ) : (
-              <MappingsTable mappings={networkMappings} />
-            )}
-          </CardBody>
-        </Card>
-      )}
-    </PageSection>
-  </>
-);
+const NetworkMappingsPage: React.FunctionComponent = () => {
+  const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1" size="lg">
+          Network mappings
+        </Title>
+      </PageSection>
+      <PageSection>
+        {isFetchingInitialNetworkMappings ? (
+          <Bullseye>
+            <EmptyState>
+              <div className="pf-c-empty-state__icon">
+                <Spinner size="xl" />
+              </div>
+              <Title headingLevel="h2">Loading...</Title>
+            </EmptyState>
+          </Bullseye>
+        ) : (
+          <Card>
+            <CardBody>
+              {!networkMappings ? null : networkMappings.length === 0 ? (
+                <EmptyState className={spacing.my_2xl}>
+                  <EmptyStateIcon icon={PlusCircleIcon} />
+                  <Title headingLevel="h2" size="lg">
+                    No network mappings
+                  </Title>
+                  <EmptyStateBody>
+                    Map source provider networks to target provider networks.
+                  </EmptyStateBody>
+                  <Button onClick={toggleAddEditModal} variant="primary">
+                    Create mapping
+                  </Button>
+                </EmptyState>
+              ) : (
+                <MappingsTable mappings={networkMappings} />
+              )}
+            </CardBody>
+          </Card>
+        )}
+      </PageSection>
+      {isAddEditModalOpen ? (
+        <AddEditMappingModal title="Add network mapping" onClose={toggleAddEditModal} />
+      ) : null}
+    </>
+  );
+};
 
 export default NetworkMappingsPage;

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -1,12 +1,66 @@
 import * as React from 'react';
-import { PageSection, Title } from '@patternfly/react-core';
+import {
+  PageSection,
+  Title,
+  Bullseye,
+  EmptyState,
+  Spinner,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Button,
+  Card,
+  CardBody,
+} from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { INetworkMapping } from '../types';
+import MappingsTable from '../components/MappingsTable';
+
+// TODO replace these with real state e.g. from redux
+const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
+const networkMappings: INetworkMapping[] = [];
 
 const NetworkMappingsPage: React.FunctionComponent = () => (
-  <PageSection>
-    <Title headingLevel="h1" size="lg">
-      Network Mappings Page Title
-    </Title>
-  </PageSection>
+  <>
+    <PageSection variant="light">
+      <Title headingLevel="h1" size="lg">
+        Network mappings
+      </Title>
+    </PageSection>
+    <PageSection>
+      {isFetchingInitialNetworkMappings ? (
+        <Bullseye>
+          <EmptyState>
+            <div className="pf-c-empty-state__icon">
+              <Spinner size="xl" />
+            </div>
+            <Title headingLevel="h2">Loading...</Title>
+          </EmptyState>
+        </Bullseye>
+      ) : (
+        <Card>
+          <CardBody>
+            {!networkMappings ? null : networkMappings.length === 0 ? (
+              <EmptyState className={spacing.my_2xl}>
+                <EmptyStateIcon icon={PlusCircleIcon} />
+                <Title headingLevel="h2" size="lg">
+                  No network mappings
+                </Title>
+                <EmptyStateBody>
+                  Map source provider networks to target provider networks.
+                </EmptyStateBody>
+                <Button onClick={() => alert('TODO')} variant="primary">
+                  Create mapping
+                </Button>
+              </EmptyState>
+            ) : (
+              <MappingsTable mappings={networkMappings} />
+            )}
+          </CardBody>
+        </Card>
+      )}
+    </PageSection>
+  </>
 );
 
 export default NetworkMappingsPage;

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -15,52 +15,58 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { IStorageMapping } from '../types';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import MappingsTable from '../components/MappingsTable';
+import AddEditMappingModal from '../components/AddEditMappingModal';
 
 // TODO replace these with real state e.g. from redux
 const isFetchingInitialStorageMappings = false; // Fetching for the first time, not polling
 const storageMappings: IStorageMapping[] = [];
 
-const StorageMappingsPage: React.FunctionComponent = () => (
-  <>
-    <PageSection variant="light">
-      <Title headingLevel="h1" size="lg">
-        Storage mappings
-      </Title>
-    </PageSection>
-    <PageSection>
-      {isFetchingInitialStorageMappings ? (
-        <Bullseye>
-          <EmptyState>
-            <div className="pf-c-empty-state__icon">
-              <Spinner size="xl" />
-            </div>
-            <Title headingLevel="h2">Loading...</Title>
-          </EmptyState>
-        </Bullseye>
-      ) : (
-        <Card>
-          <CardBody>
-            {!storageMappings ? null : storageMappings.length === 0 ? (
-              <EmptyState className={spacing.my_2xl}>
-                <EmptyStateIcon icon={PlusCircleIcon} />
-                <Title headingLevel="h2" size="lg">
-                  No storage mappings
-                </Title>
-                <EmptyStateBody>
-                  Map source provider datastores to target provider storage classes.
-                </EmptyStateBody>
-                <Button onClick={() => alert('TODO')} variant="primary">
-                  Create mapping
-                </Button>
-              </EmptyState>
-            ) : (
-              <MappingsTable mappings={storageMappings} />
-            )}
-          </CardBody>
-        </Card>
-      )}
-    </PageSection>
-  </>
-);
-
+const StorageMappingsPage: React.FunctionComponent = () => {
+  const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
+  return (
+    <>
+      <PageSection variant="light">
+        <Title headingLevel="h1" size="lg">
+          Storage mappings
+        </Title>
+      </PageSection>
+      <PageSection>
+        {isFetchingInitialStorageMappings ? (
+          <Bullseye>
+            <EmptyState>
+              <div className="pf-c-empty-state__icon">
+                <Spinner size="xl" />
+              </div>
+              <Title headingLevel="h2">Loading...</Title>
+            </EmptyState>
+          </Bullseye>
+        ) : (
+          <Card>
+            <CardBody>
+              {!storageMappings ? null : storageMappings.length === 0 ? (
+                <EmptyState className={spacing.my_2xl}>
+                  <EmptyStateIcon icon={PlusCircleIcon} />
+                  <Title headingLevel="h2" size="lg">
+                    No storage mappings
+                  </Title>
+                  <EmptyStateBody>
+                    Map source provider datastores to target provider storage classes.
+                  </EmptyStateBody>
+                  <Button onClick={toggleAddEditModal} variant="primary">
+                    Create mapping
+                  </Button>
+                </EmptyState>
+              ) : (
+                <MappingsTable mappings={storageMappings} />
+              )}
+            </CardBody>
+          </Card>
+        )}
+      </PageSection>
+      {isAddEditModalOpen ? (
+        <AddEditMappingModal title="Add storage mapping" onClose={toggleAddEditModal} />
+      ) : null}
+    </>
+  );
+};
 export default StorageMappingsPage;

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -1,12 +1,66 @@
 import * as React from 'react';
-import { PageSection, Title } from '@patternfly/react-core';
+import {
+  PageSection,
+  Title,
+  Bullseye,
+  EmptyState,
+  Spinner,
+  Card,
+  CardBody,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Button,
+} from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { IStorageMapping } from '../types';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import MappingsTable from '../components/MappingsTable';
+
+// TODO replace these with real state e.g. from redux
+const isFetchingInitialStorageMappings = false; // Fetching for the first time, not polling
+const storageMappings: IStorageMapping[] = [];
 
 const StorageMappingsPage: React.FunctionComponent = () => (
-  <PageSection>
-    <Title headingLevel="h1" size="lg">
-      Storage Mappings Page Title
-    </Title>
-  </PageSection>
+  <>
+    <PageSection variant="light">
+      <Title headingLevel="h1" size="lg">
+        Storage mappings
+      </Title>
+    </PageSection>
+    <PageSection>
+      {isFetchingInitialStorageMappings ? (
+        <Bullseye>
+          <EmptyState>
+            <div className="pf-c-empty-state__icon">
+              <Spinner size="xl" />
+            </div>
+            <Title headingLevel="h2">Loading...</Title>
+          </EmptyState>
+        </Bullseye>
+      ) : (
+        <Card>
+          <CardBody>
+            {!storageMappings ? null : storageMappings.length === 0 ? (
+              <EmptyState className={spacing.my_2xl}>
+                <EmptyStateIcon icon={PlusCircleIcon} />
+                <Title headingLevel="h2" size="lg">
+                  No storage mappings
+                </Title>
+                <EmptyStateBody>
+                  Map source provider datastores to target provider storage classes.
+                </EmptyStateBody>
+                <Button onClick={() => alert('TODO')} variant="primary">
+                  Create mapping
+                </Button>
+              </EmptyState>
+            ) : (
+              <MappingsTable mappings={storageMappings} />
+            )}
+          </CardBody>
+        </Card>
+      )}
+    </PageSection>
+  </>
 );
 
 export default StorageMappingsPage;

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Modal, Button } from '@patternfly/react-core';
+
+interface IAddEditMappingModalProps {
+  title: string;
+  onClose: () => void;
+}
+
+// TODO paramaterize similarly to MappingsTable so it can be used for both network and storage mappings?
+// Split it into AddEditNetworkMappingModal and AddEditStorageMappingModal if necessary
+
+const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = ({
+  title,
+  onClose,
+}: IAddEditMappingModalProps) => (
+  <Modal
+    variant="small"
+    title={title}
+    isOpen
+    onClose={onClose}
+    actions={[
+      <Button key="confirm" variant="primary" onClick={() => alert('TODO')}>
+        Add
+      </Button>,
+      <Button key="cancel" variant="link" onClick={onClose}>
+        Cancel
+      </Button>,
+    ]}
+  >
+    <h1>TODO: mapping builder form here</h1>
+  </Modal>
+);
+
+export default AddEditMappingModal;

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
+
+interface IMappingsTableProps {
+  mappings: Mapping[];
+}
+
+const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
+  mappings,
+}: IMappingsTableProps) => {
+  // TODO: the storage and network mappings tables seem similar enough that we
+  // can probably implement them in one place with props for the different sets
+  // of data. Code specific to networks and storages could be in separate helpers.
+  // If this turns out to be a pain, we could make NetworkMappingsTable
+  // and StorageMappingsTable separately.
+
+  // I wonder if we can make use of generics right in the props interface?
+  // Might be overkill: https://wanago.io/2020/03/09/functional-react-components-with-generic-props-in-typescript/
+
+  // TODO remove this stuff, just demonstrating how we can handle these types maybe?
+  // These kind of checks can be in helpers instead of here.
+  mappings.forEach((m) => {
+    if (m.type === MappingType.Network) {
+      const mapping = m as INetworkMapping;
+      console.log('Do something with network mapping', mapping);
+    }
+    if (m.type === MappingType.Storage) {
+      const mapping = m as IStorageMapping;
+      console.log('Do something with storage mapping', mapping);
+    }
+    return {};
+  });
+
+  return <h1>TODO: table here</h1>;
+};
+
+export default MappingsTable;

--- a/src/app/Mappings/types.ts
+++ b/src/app/Mappings/types.ts
@@ -1,0 +1,25 @@
+// TODO this structure is speculative for now.
+// These types should probably be restructured to match API data later.
+
+export enum MappingType {
+  Network = 'Network',
+  Storage = 'Storage',
+}
+
+export interface ICommonMapping {
+  type: MappingType;
+  name: string;
+  // Other stuff common to storage and network mappings
+}
+
+export interface INetworkMapping extends ICommonMapping {
+  type: MappingType.Network;
+  networkSpecificStuff: any; // TODO remove me
+}
+
+export interface IStorageMapping extends ICommonMapping {
+  type: MappingType.Storage;
+  storageSpecificStuff: any; // TODO remove me
+}
+
+export type Mapping = INetworkMapping | IStorageMapping;

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -34,7 +34,7 @@ const ProvidersPage: React.FunctionComponent = () => {
     ProviderType
   ).filter((providerType) => providers.some((provider) => provider.spec.type === providerType));
   const [activeProviderType, setActiveProviderType] = React.useState(availableProviderTypes[0]);
-  const [isAddModalOpen, setIsAddModalOpen] = React.useState(false);
+  const [isAddModalOpen, toggleAddModal] = React.useReducer((isOpen) => !isOpen, false);
   return (
     <>
       <PageSection variant="light" className={areTabsVisible ? spacing.pb_0 : ''}>
@@ -43,7 +43,7 @@ const ProvidersPage: React.FunctionComponent = () => {
             <Title headingLevel="h1">Providers</Title>
           </LevelItem>
           <LevelItem>
-            <Button variant="secondary" onClick={() => setIsAddModalOpen(true)}>
+            <Button variant="secondary" onClick={toggleAddModal}>
               Add provider
             </Button>
           </LevelItem>
@@ -85,7 +85,7 @@ const ProvidersPage: React.FunctionComponent = () => {
                     No providers
                   </Title>
                   <EmptyStateBody>Add source and target providers for migrations.</EmptyStateBody>
-                  <Button onClick={() => alert('TODO')} variant="primary">
+                  <Button onClick={toggleAddModal} variant="primary">
                     Add provider
                   </Button>
                 </EmptyState>
@@ -96,7 +96,7 @@ const ProvidersPage: React.FunctionComponent = () => {
           </Card>
         )}
       </PageSection>
-      {isAddModalOpen ? <AddProviderModal onClose={() => setIsAddModalOpen(false)} /> : null}
+      {isAddModalOpen ? <AddProviderModal onClose={toggleAddModal} /> : null}
     </>
   );
 };


### PR DESCRIPTION
Closes #6.

@ibolton336 this should unblock you if you want to start on the mappings table views.

Looking at the mockups, the storage and network mappings stuff is all very similar, so I'm hoping we can make one reusable MappingsTable and AddEditMappingModal for both. We'll see if that ends up being practical. See my code comments for some thoughts around that.