### PR TITLE
Add initial form fields, types and mock data for Add Network/Storage Mapping modal

### DIFF
--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { INetworkMapping } from '../types';
+import { INetworkMapping, MappingType } from '../types';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
 
@@ -64,7 +64,11 @@ const NetworkMappingsPage: React.FunctionComponent = () => {
         )}
       </PageSection>
       {isAddEditModalOpen ? (
-        <AddEditMappingModal title="Add network mapping" onClose={toggleAddEditModal} />
+        <AddEditMappingModal
+          title="Add network mapping"
+          onClose={toggleAddEditModal}
+          mappingType={MappingType.Network}
+        />
       ) : null}
     </>
   );

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -12,7 +12,7 @@ import {
   Button,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { IStorageMapping } from '../types';
+import { IStorageMapping, MappingType } from '../types';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
@@ -64,7 +64,11 @@ const StorageMappingsPage: React.FunctionComponent = () => {
         )}
       </PageSection>
       {isAddEditModalOpen ? (
-        <AddEditMappingModal title="Add storage mapping" onClose={toggleAddEditModal} />
+        <AddEditMappingModal
+          title="Add storage mapping"
+          onClose={toggleAddEditModal}
+          mappingType={MappingType.Storage}
+        />
       ) : null}
     </>
   );

--- a/src/app/Mappings/components/AddEditMappingModal.css
+++ b/src/app/Mappings/components/AddEditMappingModal.css
@@ -1,0 +1,3 @@
+.addEditMappingModal .extraSelectMargin {
+  margin-bottom: 150px;
+}

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -2,12 +2,27 @@ import * as React from 'react';
 import { Modal, Button, Form, FormGroup, TextInput, Grid, GridItem } from '@patternfly/react-core';
 import { MOCK_PROVIDERS } from '@app/Providers/mocks/providers.mock';
 import { SOURCE_PROVIDER_TYPES, TARGET_PROVIDER_TYPES } from '@app/common/constants';
-import SimpleSelect from '@app/common/components/SimpleSelect';
+import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import './AddEditMappingModal.css';
+import MappingBuilder from './MappingBuilder';
+import { MappingType } from '../types';
+import {
+  IVMwareNetwork,
+  ICNVNetwork,
+  IVMwareDatastore,
+  ICNVProvider,
+  IVMwareProvider,
+} from '@app/Providers/types';
+import {
+  MOCK_VMWARE_NETWORKS_BY_PROVIDER,
+  MOCK_CNV_NETWORKS_BY_PROVIDER,
+} from '@app/Providers/mocks/networks.mock';
+import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/Providers/mocks/datastores.mock';
 
 interface IAddEditMappingModalProps {
   title: string;
   onClose: () => void;
+  mappingType: MappingType;
 }
 
 // TODO paramaterize similarly to MappingsTable so it can be used for both network and storage mappings?
@@ -19,19 +34,51 @@ const providers = MOCK_PROVIDERS;
 const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = ({
   title,
   onClose,
+  mappingType,
 }: IAddEditMappingModalProps) => {
-  const sourceProviderOptions = providers
+  // TODO these might be reusable for any other provider dropdowns elsewhere in the UI
+  const sourceProviderOptions: OptionWithValue<IVMwareProvider>[] = providers
     .filter((provider) => (SOURCE_PROVIDER_TYPES as string[]).includes(provider.spec.type))
-    .map((provider) => provider.metadata.name);
-  const targetProviderOptions = providers
+    .map((provider) => ({
+      value: provider as IVMwareProvider,
+      toString: () => provider.metadata.name,
+    }));
+  const targetProviderOptions: OptionWithValue<ICNVProvider>[] = providers
     .filter((provider) => (TARGET_PROVIDER_TYPES as string[]).includes(provider.spec.type))
-    .map((provider) => provider.metadata.name);
-
-  console.log({ providers, sourceProviderOptions, targetProviderOptions });
+    .map((provider) => ({
+      value: provider as ICNVProvider,
+      toString: () => provider.metadata.name,
+    }));
 
   const [mappingName, setMappingName] = React.useState('');
-  const [sourceProvider, setSourceProvider] = React.useState('');
-  const [targetProvider, setTargetProvider] = React.useState('');
+  const [sourceProvider, setSourceProvider] = React.useState<IVMwareProvider | null>(null);
+  const [targetProvider, setTargetProvider] = React.useState<ICNVProvider | null>(null);
+
+  React.useEffect(() => {
+    console.log(`TODO: fetch ${mappingType} items for ${sourceProvider}`);
+  }, [mappingType, sourceProvider]);
+
+  React.useEffect(() => {
+    console.log(`TODO: fetch ${mappingType} items for ${targetProvider}`);
+  }, [mappingType, targetProvider]);
+
+  // TODO use the right thing from redux here instead of mock data
+  let availableSources: IVMwareNetwork[] | IVMwareDatastore[] = [];
+  let availableTargets: ICNVNetwork[] | string[] = []; // strings = storage classes
+  if (mappingType === MappingType.Network) {
+    availableSources = sourceProvider
+      ? MOCK_VMWARE_NETWORKS_BY_PROVIDER[sourceProvider.metadata.name]
+      : [];
+    availableTargets = targetProvider
+      ? MOCK_CNV_NETWORKS_BY_PROVIDER[targetProvider?.metadata.name]
+      : [];
+  }
+  if (mappingType === MappingType.Storage) {
+    availableSources = sourceProvider
+      ? MOCK_VMWARE_DATASTORES_BY_PROVIDER[sourceProvider.metadata.name]
+      : [];
+    availableTargets = targetProvider ? targetProvider.metadata.storageClasses : [];
+  }
 
   return (
     <Modal
@@ -49,7 +96,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
         </Button>,
       ]}
     >
-      <Form className="extraSelectMargin">
+      <Form className={!sourceProvider || !targetProvider ? 'extraSelectMargin' : ''}>
         <Grid sm={12} md={6} hasGutter>
           <FormGroup label="Name" isRequired fieldId="mapping-name">
             <TextInput
@@ -64,8 +111,10 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
             <SimpleSelect
               id="source-provider"
               options={sourceProviderOptions}
-              value={[sourceProviderOptions.find((option) => option === sourceProvider)]}
-              onChange={(selection) => setSourceProvider(selection as string)}
+              value={[sourceProviderOptions.find((option) => option.value === sourceProvider)]}
+              onChange={(selection) =>
+                setSourceProvider((selection as OptionWithValue<IVMwareProvider>).value)
+              }
               placeholderText="Select a source provider..."
             />
           </FormGroup>
@@ -73,12 +122,23 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
             <SimpleSelect
               id="target-provider"
               options={targetProviderOptions}
-              value={[targetProviderOptions.find((option) => option === targetProvider)]}
-              onChange={(selection) => setTargetProvider(selection as string)}
+              value={[targetProviderOptions.find((option) => option.value === targetProvider)]}
+              onChange={(selection) =>
+                setTargetProvider((selection as OptionWithValue<ICNVProvider>).value)
+              }
               placeholderText="Select a target provider..."
             />
           </FormGroup>
         </Grid>
+        {sourceProvider && targetProvider ? (
+          <MappingBuilder
+            mappingType={mappingType}
+            sourceProvider={sourceProvider}
+            targetProvider={targetProvider}
+            availableSources={availableSources}
+            availableTargets={availableTargets}
+          />
+        ) : null}
       </Form>
     </Modal>
   );

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import { Modal, Button } from '@patternfly/react-core';
+import { Modal, Button, Form, FormGroup, TextInput, Grid, GridItem } from '@patternfly/react-core';
+import { MOCK_PROVIDERS } from '@app/Providers/mocks/providers.mock';
+import { SOURCE_PROVIDER_TYPES, TARGET_PROVIDER_TYPES } from '@app/common/constants';
+import SimpleSelect from '@app/common/components/SimpleSelect';
+import './AddEditMappingModal.css';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -9,26 +13,75 @@ interface IAddEditMappingModalProps {
 // TODO paramaterize similarly to MappingsTable so it can be used for both network and storage mappings?
 // Split it into AddEditNetworkMappingModal and AddEditStorageMappingModal if necessary
 
+// TODO replace these with real state e.g. from redux
+const providers = MOCK_PROVIDERS;
+
 const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = ({
   title,
   onClose,
-}: IAddEditMappingModalProps) => (
-  <Modal
-    variant="small"
-    title={title}
-    isOpen
-    onClose={onClose}
-    actions={[
-      <Button key="confirm" variant="primary" onClick={() => alert('TODO')}>
-        Add
-      </Button>,
-      <Button key="cancel" variant="link" onClick={onClose}>
-        Cancel
-      </Button>,
-    ]}
-  >
-    <h1>TODO: mapping builder form here</h1>
-  </Modal>
-);
+}: IAddEditMappingModalProps) => {
+  const sourceProviderOptions = providers
+    .filter((provider) => (SOURCE_PROVIDER_TYPES as string[]).includes(provider.spec.type))
+    .map((provider) => provider.metadata.name);
+  const targetProviderOptions = providers
+    .filter((provider) => (TARGET_PROVIDER_TYPES as string[]).includes(provider.spec.type))
+    .map((provider) => provider.metadata.name);
+
+  console.log({ providers, sourceProviderOptions, targetProviderOptions });
+
+  const [mappingName, setMappingName] = React.useState('');
+  const [sourceProvider, setSourceProvider] = React.useState('');
+  const [targetProvider, setTargetProvider] = React.useState('');
+
+  return (
+    <Modal
+      className="addEditMappingModal"
+      width="80%"
+      title={title}
+      isOpen
+      onClose={onClose}
+      actions={[
+        <Button key="confirm" variant="primary" onClick={() => alert('TODO')}>
+          Add
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Form className="extraSelectMargin">
+        <Grid sm={12} md={6} hasGutter>
+          <FormGroup label="Name" isRequired fieldId="mapping-name">
+            <TextInput
+              id="mapping-name"
+              value={mappingName}
+              type="text"
+              onChange={setMappingName}
+            />
+          </FormGroup>
+          <GridItem />
+          <FormGroup label="Source provider" isRequired fieldId="source-provider">
+            <SimpleSelect
+              id="source-provider"
+              options={sourceProviderOptions}
+              value={[sourceProviderOptions.find((option) => option === sourceProvider)]}
+              onChange={(selection) => setSourceProvider(selection as string)}
+              placeholderText="Select a source provider..."
+            />
+          </FormGroup>
+          <FormGroup label="Target provider" isRequired fieldId="target-provider">
+            <SimpleSelect
+              id="target-provider"
+              options={targetProviderOptions}
+              value={[targetProviderOptions.find((option) => option === targetProvider)]}
+              onChange={(selection) => setTargetProvider(selection as string)}
+              placeholderText="Select a target provider..."
+            />
+          </FormGroup>
+        </Grid>
+      </Form>
+    </Modal>
+  );
+};
 
 export default AddEditMappingModal;

--- a/src/app/Mappings/components/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const MappingBuilder: React.FunctionComponent = () => null;
+
+export default MappingBuilder;

--- a/src/app/Mappings/components/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder.tsx
@@ -1,5 +1,30 @@
 import * as React from 'react';
+import { MappingType } from '../types';
+import {
+  IVMwareNetwork,
+  IVMwareDatastore,
+  ICNVNetwork,
+  IVMwareProvider,
+  ICNVProvider,
+} from '@app/Providers/types';
 
-const MappingBuilder: React.FunctionComponent = () => null;
+interface IMappingBuilderProps {
+  mappingType: MappingType;
+  sourceProvider: IVMwareProvider;
+  targetProvider: ICNVProvider;
+  availableSources: IVMwareNetwork[] | IVMwareDatastore[];
+  availableTargets: ICNVNetwork[] | string[]; // strings = storage classes
+}
+
+const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
+  mappingType,
+  sourceProvider,
+  targetProvider,
+  availableSources,
+  availableTargets,
+}: IMappingBuilderProps) => {
+  console.log({ mappingType, sourceProvider, targetProvider, availableSources, availableTargets });
+  return <h1>TODO: mapping builder</h1>;
+};
 
 export default MappingBuilder;

--- a/src/app/Mappings/types.ts
+++ b/src/app/Mappings/types.ts
@@ -1,25 +1,49 @@
 // TODO this structure is speculative for now.
 // These types should probably be restructured to match API data later.
 
+import { ProviderType } from '@app/common/constants';
+import { ICNVNetwork } from '@app/Providers/types';
+
 export enum MappingType {
   Network = 'Network',
   Storage = 'Storage',
 }
 
+export interface INetworkMappingItem {
+  src: {
+    id: string;
+  };
+  target: ICNVNetwork;
+}
+
+export interface IStorageMappingItem {
+  src: {
+    id: string;
+  };
+  target: {
+    storageClass: string;
+  };
+}
+
 export interface ICommonMapping {
   type: MappingType;
   name: string;
-  // Other stuff common to storage and network mappings
+  provider: {
+    // TODO Should this instead use a unique provider id? what if we rename providers?
+    type: ProviderType;
+    name: string;
+  };
+  items: INetworkMappingItem[] | IStorageMappingItem[];
 }
 
 export interface INetworkMapping extends ICommonMapping {
   type: MappingType.Network;
-  networkSpecificStuff: any; // TODO remove me
+  items: INetworkMappingItem[];
 }
 
 export interface IStorageMapping extends ICommonMapping {
   type: MappingType.Storage;
-  storageSpecificStuff: any; // TODO remove me
+  items: IStorageMappingItem[];
 }
 
 export type Mapping = INetworkMapping | IStorageMapping;

--- a/src/app/Providers/mocks/datastores.mock.ts
+++ b/src/app/Providers/mocks/datastores.mock.ts
@@ -1,0 +1,15 @@
+import { IVMwareDatastore, IVMwareDatastoresByProvider } from '../types';
+
+const someVMwareDatastores: IVMwareDatastore[] = [
+  { id: '1', name: 'vmware-datastore-1' },
+  { id: '2', name: 'vmware-datastore-2' },
+  { id: '3', name: 'vmware-datastore-3' },
+  { id: '4', name: 'vmware-datastore-4' },
+  { id: '5', name: 'vmware-datastore-5' },
+];
+
+export const MOCK_VMWARE_DATASTORES_BY_PROVIDER: IVMwareDatastoresByProvider = {
+  VCenter1: [...someVMwareDatastores],
+  VCenter2: [...someVMwareDatastores],
+  VCenter3: [...someVMwareDatastores],
+};

--- a/src/app/Providers/mocks/networks.mock.ts
+++ b/src/app/Providers/mocks/networks.mock.ts
@@ -1,0 +1,34 @@
+import {
+  IVMwareNetwork,
+  IVMwareNetworksByProvider,
+  ICNVNetworksByProvider,
+  ICNVNetwork,
+  NetworkType,
+} from '../types';
+
+const someVMwareNetworks: IVMwareNetwork[] = [
+  { id: '1', name: 'vmware-network-1' },
+  { id: '2', name: 'vmware-network-2' },
+  { id: '3', name: 'vmware-network-3' },
+  { id: '4', name: 'vmware-network-4' },
+  { id: '5', name: 'vmware-network-5' },
+];
+
+export const MOCK_VMWARE_NETWORKS_BY_PROVIDER: IVMwareNetworksByProvider = {
+  VCenter1: [...someVMwareNetworks],
+  VCenter2: [...someVMwareNetworks],
+  VCenter3: [...someVMwareNetworks],
+};
+
+const someCNVNetworks: ICNVNetwork[] = [
+  { type: NetworkType.Pod, name: 'ocp-pod-network-1', namespace: 'ocp-namespace-1' },
+  { type: NetworkType.Pod, name: 'ocp-pod-network-2', namespace: 'ocp-namespace-1' },
+  { type: NetworkType.Multis, name: 'ocp-multis-network-1', namespace: 'ocp-namespace-1' },
+  { type: NetworkType.Multis, name: 'ocp-multis-network-2', namespace: 'ocp-namespace-1' },
+];
+
+export const MOCK_CNV_NETWORKS_BY_PROVIDER: ICNVNetworksByProvider = {
+  OCPv_1: [...someCNVNetworks],
+  OCPv_2: [...someCNVNetworks],
+  OCPv_3: [...someCNVNetworks],
+};

--- a/src/app/Providers/types.ts
+++ b/src/app/Providers/types.ts
@@ -80,6 +80,43 @@ export interface IHost {
   };
 }
 
+// TODO do these need to be indexed by provider id instead of name?
 export interface IHostsByProvider {
   [providerName: string]: IHost[];
+}
+
+export interface IVMwareNetwork {
+  id: string;
+  name: string;
+}
+
+// TODO not sure if these are right
+export enum NetworkType {
+  Pod = 'pod',
+  Multis = 'multis',
+}
+
+export interface ICNVNetwork {
+  type: NetworkType;
+  name: string;
+  namespace: string;
+}
+
+// TODO do these need to be indexed by provider id instead of name?
+export interface IVMwareNetworksByProvider {
+  [providerName: string]: IVMwareNetwork[];
+}
+
+export interface ICNVNetworksByProvider {
+  [providerName: string]: ICNVNetwork[];
+}
+
+export interface IVMwareDatastore {
+  id: string;
+  name: string;
+}
+
+// TODO do these need to be indexed by provider id instead of name?
+export interface IVMwareDatastoresByProvider {
+  [providerName: string]: IVMwareDatastore[];
 }

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -14,3 +14,6 @@ export const PROVIDER_TYPE_NAMES = {
   [ProviderType.vsphere]: 'VMware',
   [ProviderType.cnv]: 'OpenShift Virtualization',
 };
+
+export const SOURCE_PROVIDER_TYPES = [ProviderType.vsphere];
+export const TARGET_PROVIDER_TYPES = [ProviderType.cnv];


### PR DESCRIPTION
Working towards #7. The mapping builder itself is still WIP and moved to another branch, I figured it was worth merging the rest of this skeleton first so we can share the TypeScript types @ibolton336 .

Disregard the branch name. Thought I would get to the mapping widget in this one.