### PR TITLE
Add network/storage mappings table component

### DIFF
--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -16,19 +16,20 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { INetworkMapping, MappingType } from '../types';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
+import { fetchMockStorage } from '../mocks/helpers';
 
 // TODO replace these with real state e.g. from redux
 const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
 // const networkMappings: INetworkMapping[] = [];
 
 const NetworkMappingsPage: React.FunctionComponent = () => {
-  const mockMapObj = localStorage.getItem('mappingsObject');
   const [networkMappings, setNetworkMappings] = React.useState([]);
 
+  //TODO replace with real state from redux
+  const mockMapObj = localStorage.getItem('networkMappingsObject');
   React.useEffect(() => {
     console.log(`TODO: fetch network mapping items`);
-    const mappingsKey = localStorage.getItem('mappingsObject' || '{}');
-    const currentMappings = mappingsKey !== null ? JSON.parse(mappingsKey).mappings : [];
+    const currentMappings = fetchMockStorage(MappingType.Network);
     setNetworkMappings(currentMappings || []);
   }, [mockMapObj]);
 

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -18,15 +18,13 @@ import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
 import { fetchMockStorage } from '../mocks/helpers';
 
-// TODO replace these with real state e.g. from redux
 const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
-// const networkMappings: INetworkMapping[] = [];
 
 const NetworkMappingsPage: React.FunctionComponent = () => {
-  //TODO replace with real state from redux
-  const [networkMappings, setNetworkMappings] = React.useState([]);
+  //TODO: replace with real state from redux
+  const [networkMappings, setNetworkMappings] = React.useState<INetworkMapping[]>([]);
 
-  //TODO replace with real state from redux
+  //TODO: replace with real state from redux
   const mockMapObj = localStorage.getItem('networkMappingsObject');
   React.useEffect(() => {
     console.log(`TODO: fetch network mapping items`);

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -57,7 +57,7 @@ const NetworkMappingsPage: React.FunctionComponent = () => {
                   </Button>
                 </EmptyState>
               ) : (
-                <MappingsTable mappings={networkMappings} />
+                <MappingsTable mappings={networkMappings} mappingType={MappingType.Network} />
               )}
             </CardBody>
           </Card>

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -19,9 +19,19 @@ import AddEditMappingModal from '../components/AddEditMappingModal';
 
 // TODO replace these with real state e.g. from redux
 const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
-const networkMappings: INetworkMapping[] = [];
+// const networkMappings: INetworkMapping[] = [];
 
 const NetworkMappingsPage: React.FunctionComponent = () => {
+  const mockMapObj = localStorage.getItem('mappingsObject');
+  const [networkMappings, setNetworkMappings] = React.useState([]);
+
+  React.useEffect(() => {
+    console.log(`TODO: fetch network mapping items`);
+    const mappingsKey = localStorage.getItem('mappingsObject' || '{}');
+    const currentMappings = mappingsKey !== null ? JSON.parse(mappingsKey).mappings : [];
+    setNetworkMappings(currentMappings || []);
+  }, [mockMapObj]);
+
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
   return (
     <>

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -23,6 +23,7 @@ const isFetchingInitialNetworkMappings = false; // Fetching for the first time, 
 // const networkMappings: INetworkMapping[] = [];
 
 const NetworkMappingsPage: React.FunctionComponent = () => {
+  //TODO replace with real state from redux
   const [networkMappings, setNetworkMappings] = React.useState([]);
 
   //TODO replace with real state from redux

--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -67,7 +67,11 @@ const NetworkMappingsPage: React.FunctionComponent = () => {
                   </Button>
                 </EmptyState>
               ) : (
-                <MappingsTable mappings={networkMappings} mappingType={MappingType.Network} />
+                <MappingsTable
+                  mappings={networkMappings}
+                  mappingType={MappingType.Network}
+                  toggleAddEditModal={toggleAddEditModal}
+                />
               )}
             </CardBody>
           </Card>

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -23,10 +23,11 @@ const isFetchingInitialStorageMappings = false; // Fetching for the first time, 
 // const storageMappings: IStorageMapping[] = [];
 
 const StorageMappingsPage: React.FunctionComponent = () => {
+  //TODO: replace with real state from redux
   const [storageMappings, setStorageMappings] = React.useState([]);
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
 
-  //TODO replace with real state from redux
+  //TODO: replace with real state from redux
   const mockMapObj = localStorage.getItem('storageMappingsObject');
   React.useEffect(() => {
     console.log(`TODO: fetch storage mapping items`);

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -57,7 +57,7 @@ const StorageMappingsPage: React.FunctionComponent = () => {
                   </Button>
                 </EmptyState>
               ) : (
-                <MappingsTable mappings={storageMappings} />
+                <MappingsTable mappings={storageMappings} mappingType={MappingType.Storage} />
               )}
             </CardBody>
           </Card>

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -57,7 +57,11 @@ const StorageMappingsPage: React.FunctionComponent = () => {
                   </Button>
                 </EmptyState>
               ) : (
-                <MappingsTable mappings={storageMappings} mappingType={MappingType.Storage} />
+                <MappingsTable
+                  mappings={storageMappings}
+                  mappingType={MappingType.Storage}
+                  toggleAddEditModal={toggleAddEditModal}
+                />
               )}
             </CardBody>
           </Card>

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -18,13 +18,11 @@ import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
 import { fetchMockStorage } from '../mocks/helpers';
 
-// TODO replace these with real state e.g. from redux
 const isFetchingInitialStorageMappings = false; // Fetching for the first time, not polling
-// const storageMappings: IStorageMapping[] = [];
 
 const StorageMappingsPage: React.FunctionComponent = () => {
   //TODO: replace with real state from redux
-  const [storageMappings, setStorageMappings] = React.useState([]);
+  const [storageMappings, setStorageMappings] = React.useState<IStorageMapping[]>([]);
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
 
   //TODO: replace with real state from redux

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -16,13 +16,24 @@ import { IStorageMapping, MappingType } from '../types';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
+import { fetchMockStorage } from '../mocks/helpers';
 
 // TODO replace these with real state e.g. from redux
 const isFetchingInitialStorageMappings = false; // Fetching for the first time, not polling
-const storageMappings: IStorageMapping[] = [];
+// const storageMappings: IStorageMapping[] = [];
 
 const StorageMappingsPage: React.FunctionComponent = () => {
+  const [storageMappings, setStorageMappings] = React.useState([]);
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
+
+  //TODO replace with real state from redux
+  const mockMapObj = localStorage.getItem('storageMappingsObject');
+  React.useEffect(() => {
+    console.log(`TODO: fetch storage mapping items`);
+    const currentMappings = fetchMockStorage(MappingType.Storage);
+    setStorageMappings(currentMappings || []);
+  }, [mockMapObj]);
+
   return (
     <>
       <PageSection variant="light">

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -104,9 +104,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                 targetProvider,
                 builderItems,
               });
-              // alert('TODO');
-              console.log('TODO: API call with generated mapping: ', generatedMapping);
-              //TODO: Remove when real api call is implemented
+              //TODO: Update when real api call & validation is implemented
               updateMockStorage(generatedMapping);
               onClose();
             }

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -113,7 +113,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
             }
 =======
             //TODO: Replace with a real redux call for adding a mapping
-            updateMockStorage({ mappingName, sourceProvider, targetProvider });
+            updateMockStorage({ mappingName, sourceProvider, targetProvider, mappingType });
             onClose();
 >>>>>>> move mock function to its own file
           }}

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -13,11 +13,7 @@ import {
   MOCK_CNV_NETWORKS_BY_PROVIDER,
 } from '@app/Providers/mocks/networks.mock';
 import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/Providers/mocks/datastores.mock';
-<<<<<<< HEAD
 import './AddEditMappingModal.css';
-=======
-import { updateMockStorage } from '../mocks/helpers';
->>>>>>> move mock function to its own file
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -99,7 +95,6 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
           key="confirm"
           variant="primary"
           onClick={() => {
-<<<<<<< HEAD
             if (sourceProvider && targetProvider) {
               const generatedMapping = getMappingFromBuilderItems({
                 mappingType,
@@ -111,11 +106,6 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
               alert('TODO');
               console.log('TODO: API call with generated mapping: ', generatedMapping);
             }
-=======
-            //TODO: Replace with a real redux call for adding a mapping
-            updateMockStorage({ mappingName, sourceProvider, targetProvider, mappingType });
-            onClose();
->>>>>>> move mock function to its own file
           }}
         >
           Create

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@app/Providers/mocks/networks.mock';
 import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/Providers/mocks/datastores.mock';
 import './AddEditMappingModal.css';
+import { updateMockStorage } from '../mocks/helpers';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -103,8 +104,11 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                 targetProvider,
                 builderItems,
               });
-              alert('TODO');
+              // alert('TODO');
               console.log('TODO: API call with generated mapping: ', generatedMapping);
+              //TODO: Remove when real api call is implemented
+              updateMockStorage(generatedMapping);
+              onClose();
             }
           }}
         >

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -13,7 +13,11 @@ import {
   MOCK_CNV_NETWORKS_BY_PROVIDER,
 } from '@app/Providers/mocks/networks.mock';
 import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/Providers/mocks/datastores.mock';
+<<<<<<< HEAD
 import './AddEditMappingModal.css';
+=======
+import { updateMockStorage } from '../mocks/helpers';
+>>>>>>> move mock function to its own file
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -95,6 +99,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
           key="confirm"
           variant="primary"
           onClick={() => {
+<<<<<<< HEAD
             if (sourceProvider && targetProvider) {
               const generatedMapping = getMappingFromBuilderItems({
                 mappingType,
@@ -106,6 +111,11 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
               alert('TODO');
               console.log('TODO: API call with generated mapping: ', generatedMapping);
             }
+=======
+            //TODO: Replace with a real redux call for adding a mapping
+            updateMockStorage({ mappingName, sourceProvider, targetProvider });
+            onClose();
+>>>>>>> move mock function to its own file
           }}
         >
           Create

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
+
+const MappingsActionsDropdown: React.FunctionComponent = () => {
+  const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
+  return (
+    <Dropdown
+      aria-label="Actions"
+      toggle={<KebabToggle onToggle={() => setKebabIsOpen(!kebabIsOpen)} />}
+      isOpen={kebabIsOpen}
+      isPlain
+      dropdownItems={[
+        <DropdownItem
+          onClick={() => {
+            setKebabIsOpen(false);
+            alert('TODO');
+          }}
+          key="edit"
+        >
+          Edit
+        </DropdownItem>,
+        <DropdownItem
+          onClick={() => {
+            setKebabIsOpen(false);
+            alert('TODO');
+          }}
+          key="remove"
+        >
+          Remove
+        </DropdownItem>,
+      ]}
+      position={DropdownPosition.right}
+    />
+  );
+};
+
+export default MappingsActionsDropdown;

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -22,7 +22,7 @@ import {
 import { useSortState, usePaginationState, useSelectionState } from '@app/common/hooks';
 import { IVMwareProvider } from '@app/Providers/types';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import { OutlinedHddIcon } from '@patternfly/react-icons';
+import { OutlinedHddIcon, NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
 import ProviderStatus from '@app/Providers/components/ProvidersTable/ProviderStatus';
 import VMwareProviderActionsDropdown from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderActionsDropdown';
 import VMwareProviderHostsTable from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderHostsTable';
@@ -57,7 +57,11 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     { title: 'Name', transforms: [sortable] },
     { title: 'Source provider', transforms: [sortable] },
     { title: 'Target provider', transforms: [sortable] },
-    { title: 'Network mappings', transforms: [sortable] },
+    {
+      title: <>{mappingType === MappingType.Network ? 'Network mappings' : 'Storage mappings'}</>,
+      transforms: [sortable],
+      cellTransforms: [compoundExpand],
+    },
     { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
   ];
 
@@ -75,7 +79,12 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         {
           title: (
             <>
-              <OutlinedHddIcon key="hosts-icon" /> {items ? items.length : 0}
+              {mappingType === MappingType.Network ? (
+                <NetworkIcon key="hosts-icon" />
+              ) : (
+                <DatabaseIcon key="storage-icon" />
+              )}{' '}
+              {items ? items.length : 0}
             </>
           ),
           props: {
@@ -95,8 +104,8 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
           {
             title: (
               <div>
-                mapping details table
-                {/* <MappingDetailsTable provider={provider} /> */}
+                TODO: mapping details table
+                {/* <MappingDetailsTable {...props} /> */}
               </div>
             ),
             props: { colSpan: columns.length, className: tableStyles.modifiers.noPadding },
@@ -148,13 +157,13 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         </LevelItem>
       </Level>
       <Table
-        aria-label="VMware providers table"
+        aria-label="Mappings table"
         cells={columns}
         rows={rows}
         sortBy={sortBy}
         onSort={onSort}
         onExpand={(_event, _rowIndex, _colIndex, _isOpen, rowData) => {
-          toggleMappingExpanded(rowData.meta.provider);
+          toggleMappingExpanded(rowData.meta.mapping);
         }}
       >
         <TableHeader />

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -35,6 +35,7 @@ interface IMappingsTableProps {
 
 const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   mappings,
+  mappingType,
 }: IMappingsTableProps) => {
   const getSortValues = (mapping: ICommonMapping) => {
     const { name, sourceProvider, targetProvider } = mapping;
@@ -72,7 +73,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         {
           title: (
             <>
-              <OutlinedHddIcon key="hosts-icon" /> {items.length}
+              <OutlinedHddIcon key="hosts-icon" /> {items ? items.length : 0}
             </>
           ),
           props: {

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -1,13 +1,107 @@
 import * as React from 'react';
-import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
+import {
+  Mapping,
+  MappingType,
+  INetworkMapping,
+  IStorageMapping,
+  ICommonMapping,
+  INetworkMappingItem,
+  IStorageMappingItem,
+} from '../types';
+import { Level, LevelItem, Button, Pagination } from '@patternfly/react-core';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  ICell,
+  sortable,
+  compoundExpand,
+  classNames as classNamesTransform,
+  IRow,
+} from '@patternfly/react-table';
+import { useSortState, usePaginationState, useSelectionState } from '@app/common/hooks';
+import { IVMwareProvider } from '@app/Providers/types';
+import tableStyles from '@patternfly/react-styles/css/components/Table/table';
+import { OutlinedHddIcon } from '@patternfly/react-icons';
+import ProviderStatus from '@app/Providers/components/ProvidersTable/ProviderStatus';
+import VMwareProviderActionsDropdown from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderActionsDropdown';
+import VMwareProviderHostsTable from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderHostsTable';
+import MappingsActionsDropdown from './MappingsActionsDropdown';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
+  mappingType: string;
 }
 
 const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   mappings,
 }: IMappingsTableProps) => {
+  const getSortValues = (mapping: ICommonMapping) => {
+    const { name, sourceProvider, targetProvider } = mapping;
+    return [name, sourceProvider.name, targetProvider.name, ''];
+  };
+
+  const { sortBy, onSort, sortedItems } = useSortState(mappings, getSortValues);
+  const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
+  React.useEffect(() => setPageNumber(1), [sortBy, setPageNumber]);
+
+  const {
+    selectedItems: expandedMappings,
+    toggleItemSelected: toggleMappingExpanded,
+  } = useSelectionState<ICommonMapping>(sortedItems);
+
+  const columns: ICell[] = [
+    { title: 'Name', transforms: [sortable] },
+    { title: 'Source provider', transforms: [sortable] },
+    { title: 'Target provider', transforms: [sortable] },
+    { title: 'Network mappings', transforms: [sortable] },
+    { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
+  ];
+
+  const rows: IRow[] = [];
+  currentPageItems.forEach((mapping: ICommonMapping) => {
+    const { name, sourceProvider, targetProvider, items } = mapping;
+    const isExpanded = expandedMappings.includes(mapping);
+    rows.push({
+      meta: { mapping },
+      isOpen: isExpanded,
+      cells: [
+        name,
+        sourceProvider.name,
+        targetProvider.name,
+        {
+          title: (
+            <>
+              <OutlinedHddIcon key="hosts-icon" /> {items.length}
+            </>
+          ),
+          props: {
+            isOpen: isExpanded,
+          },
+        },
+        {
+          title: <MappingsActionsDropdown />,
+        },
+      ],
+    });
+    if (isExpanded) {
+      rows.push({
+        parent: rows.length - 1,
+        compoundExpand: 4,
+        cells: [
+          {
+            title: (
+              <div>
+                mapping details table
+                {/* <MappingDetailsTable provider={provider} /> */}
+              </div>
+            ),
+            props: { colSpan: columns.length, className: tableStyles.modifiers.noPadding },
+          },
+        ],
+      });
+    }
+  });
   // TODO: the storage and network mappings tables seem similar enough that we
   // can probably implement them in one place with props for the different sets
   // of data. Code specific to networks and storages could be in separate helpers.
@@ -31,7 +125,43 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     return {};
   });
 
-  return <h1>TODO: table here</h1>;
+  return (
+    <>
+      <Level>
+        <LevelItem>
+          {/* <Button
+            variant="secondary"
+            onClick={() => alert('TODO')}
+            isDisabled={selectedItems.length === 0}
+          >
+            Download data
+          </Button> */}
+          level item
+        </LevelItem>
+        <LevelItem>
+          <Pagination {...paginationProps} widgetId="providers-table-pagination-top" />
+        </LevelItem>
+      </Level>
+      <Table
+        aria-label="VMware providers table"
+        cells={columns}
+        rows={rows}
+        sortBy={sortBy}
+        onSort={onSort}
+        onExpand={(_event, _rowIndex, _colIndex, _isOpen, rowData) => {
+          toggleMappingExpanded(rowData.meta.provider);
+        }}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+      <Pagination
+        {...paginationProps}
+        widgetId="providers-table-pagination-bottom"
+        variant="bottom"
+      />
+    </>
+  );
 };
 
 export default MappingsTable;

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -31,11 +31,13 @@ import MappingsActionsDropdown from './MappingsActionsDropdown';
 interface IMappingsTableProps {
   mappings: Mapping[];
   mappingType: string;
+  toggleAddEditModal: () => void;
 }
 
 const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   mappings,
   mappingType,
+  toggleAddEditModal,
 }: IMappingsTableProps) => {
   const getSortValues = (mapping: ICommonMapping) => {
     const { name, sourceProvider, targetProvider } = mapping;
@@ -130,14 +132,16 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     <>
       <Level>
         <LevelItem>
-          {/* <Button
-            variant="secondary"
-            onClick={() => alert('TODO')}
-            isDisabled={selectedItems.length === 0}
+          <Button
+            key="confirm"
+            variant="primary"
+            onClick={() => {
+              //TODO: Replace with a real redux call for adding a mapping
+              toggleAddEditModal();
+            }}
           >
-            Download data
-          </Button> */}
-          level item
+            Add mapping
+          </Button>
         </LevelItem>
         <LevelItem>
           <Pagination {...paginationProps} widgetId="providers-table-pagination-top" />

--- a/src/app/Mappings/mocks/helpers.ts
+++ b/src/app/Mappings/mocks/helpers.ts
@@ -1,7 +1,7 @@
-import { MappingType } from '../types';
+import { MappingType, Mapping } from '../types';
 
-export const updateMockStorage = (params: any) => {
-  const { mappingName, sourceProvider, targetProvider, mappingType } = params;
+export const updateMockStorage = (generatedMapping: Mapping) => {
+  const { name: mappingName, provider, type: mappingType, items } = generatedMapping;
   const mappingsKey =
     mappingType === MappingType.Network ? 'networkMappingsObject' : 'storageMappingsObject';
   const mappingsStorageItem = localStorage.getItem(mappingsKey);
@@ -10,11 +10,13 @@ export const updateMockStorage = (params: any) => {
     mappings: [
       {
         name: mappingName ? mappingName : 'name1',
-        sourceProvider: {
-          name: sourceProvider ? sourceProvider.metadata.name : 'test1',
-        },
-        targetProvider: {
-          name: targetProvider ? targetProvider.metadata.name : 'test2',
+        provider: {
+          source: {
+            name: provider.source.name,
+          },
+          target: {
+            name: provider.source.name,
+          },
         },
       },
       ...(currentMappings?.mappings ? currentMappings.mappings : []),

--- a/src/app/Mappings/mocks/helpers.ts
+++ b/src/app/Mappings/mocks/helpers.ts
@@ -1,7 +1,11 @@
+import { MappingType } from '../types';
+
 export const updateMockStorage = (params: any) => {
-  const { mappingName, sourceProvider, targetProvider } = params;
-  const mappingsKey = localStorage.getItem('mappingsObject' || '{}');
-  const currentMappings = mappingsKey !== null ? JSON.parse(mappingsKey) : {};
+  const { mappingName, sourceProvider, targetProvider, mappingType } = params;
+  const mappingsKey =
+    mappingType === MappingType.Network ? 'networkMappingsObject' : 'storageMappingsObject';
+  const mappingsStorageItem = localStorage.getItem(mappingsKey);
+  const currentMappings = mappingsKey !== null ? JSON.parse(mappingsStorageItem || '{}') : {};
   const mockMappings = {
     mappings: [
       {
@@ -16,5 +20,13 @@ export const updateMockStorage = (params: any) => {
       ...(currentMappings?.mappings ? currentMappings.mappings : []),
     ],
   };
-  localStorage.setItem('mappingsObject', JSON.stringify(mockMappings));
+  localStorage.setItem(mappingsKey, JSON.stringify(mockMappings));
+};
+
+export const fetchMockStorage = (mappingType: string) => {
+  const mappingsKey =
+    mappingType === MappingType.Network ? 'networkMappingsObject' : 'storageMappingsObject';
+  const mappingsItem = localStorage.getItem(mappingsKey);
+  const returnVal = JSON.parse(mappingsItem || '{}').mappings;
+  return returnVal;
 };

--- a/src/app/Mappings/mocks/helpers.ts
+++ b/src/app/Mappings/mocks/helpers.ts
@@ -1,5 +1,6 @@
 import { MappingType, Mapping } from '../types';
 
+// TODO: This is a temporary function designed for testing the mappings table. Remove when we wire up Redux & api
 export const updateMockStorage = (generatedMapping: Mapping) => {
   const { name: mappingName, provider, type: mappingType, items } = generatedMapping;
   const mappingsKey =

--- a/src/app/Mappings/mocks/helpers.ts
+++ b/src/app/Mappings/mocks/helpers.ts
@@ -1,0 +1,20 @@
+export const updateMockStorage = (params: any) => {
+  const { mappingName, sourceProvider, targetProvider } = params;
+  const mappingsKey = localStorage.getItem('mappingsObject' || '{}');
+  const currentMappings = mappingsKey !== null ? JSON.parse(mappingsKey) : {};
+  const mockMappings = {
+    mappings: [
+      {
+        name: mappingName ? mappingName : 'name1',
+        sourceProvider: {
+          name: sourceProvider ? sourceProvider.metadata.name : 'test1',
+        },
+        targetProvider: {
+          name: targetProvider ? targetProvider.metadata.name : 'test2',
+        },
+      },
+      ...(currentMappings?.mappings ? currentMappings.mappings : []),
+    ],
+  };
+  localStorage.setItem('mappingsObject', JSON.stringify(mockMappings));
+};


### PR DESCRIPTION
- Adds necessary logic to populate the shared mappings table with network or storage mappings. 
- Adds Add mapping button to the top of the shared table. This button opens the shared mappings modal
- Uses mock data in local storage for testing. There are a few throwaway functions added to /mocks/helpers for this purpose. We can use these until we are ready for redux implementation. 

Closes #31 