### PR TITLE
Add MappingDetailView and use in expanded content of mappings table rows

### DIFF
--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -29,7 +29,7 @@ const NetworkMappingsPage: React.FunctionComponent = () => {
   React.useEffect(() => {
     console.log(`TODO: fetch network mapping items`);
     const currentMappings = fetchMockStorage(MappingType.Network);
-    setNetworkMappings(currentMappings || []);
+    setNetworkMappings((currentMappings as INetworkMapping[]) || []);
   }, [mockMapObj]);
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -30,7 +30,7 @@ const StorageMappingsPage: React.FunctionComponent = () => {
   React.useEffect(() => {
     console.log(`TODO: fetch storage mapping items`);
     const currentMappings = fetchMockStorage(MappingType.Storage);
-    setStorageMappings(currentMappings || []);
+    setStorageMappings((currentMappings as IStorageMapping[]) || []);
   }, [mockMapObj]);
 
   return (

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.css
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.css
@@ -1,4 +1,4 @@
-.mapping-viewer-box {
+.mapping-builder-box {
   border: 1px solid #000000;
 }
 

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -3,7 +3,7 @@ import { Button, TextContent, Text, Grid, GridItem, Bullseye, Flex } from '@patt
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { MappingType, MappingSource, MappingTarget } from '../../types';
-import LineArrow from '@app/common/components/LineArrow/LineArrow';
+import LineArrow from '@app/common/components/LineArrow';
 import MappingSourceSelect from './MappingSourceSelect';
 import MappingTargetSelect from './MappingTargetSelect';
 import './MappingBuilder.css';
@@ -84,7 +84,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 <GridItem span={1} />
               </>
             ) : null}
-            <GridItem span={5} className={`mapping-viewer-box ${spacing.pSm}`}>
+            <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
               <MappingSourceSelect
                 id={`mapping-sources-for-${key}`}
                 builderItems={builderItems}
@@ -99,7 +99,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 <LineArrow />
               </Bullseye>
             </GridItem>
-            <GridItem span={5} className={`mapping-viewer-box ${spacing.pSm}`}>
+            <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
               <MappingTargetSelect
                 id={`mapping-target-for-${key}`}
                 mappingType={mappingType}

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -6,6 +6,8 @@ import { MappingType, MappingSource, MappingTarget } from '../../types';
 import LineArrow from '@app/common/components/LineArrow';
 import MappingSourceSelect from './MappingSourceSelect';
 import MappingTargetSelect from './MappingTargetSelect';
+import { getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
+
 import './MappingBuilder.css';
 
 export interface IMappingBuilderItem {
@@ -40,21 +42,15 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
   };
 
   let instructionText = '';
-  let sourceHeadingText = '';
-  let targetHeadingText = '';
   let selectSourcePlaceholder = '';
   let selectTargetPlaceholder = '';
   if (mappingType === MappingType.Network) {
     instructionText = 'Map source and target networks.';
-    sourceHeadingText = 'Source networks';
-    targetHeadingText = 'Target networks';
     selectSourcePlaceholder = 'Select source...';
     selectTargetPlaceholder = 'Select target...';
   }
   if (mappingType === MappingType.Storage) {
     instructionText = 'Map source datastores to target storage classes.';
-    sourceHeadingText = 'Source datastores';
-    targetHeadingText = 'Target storage classes';
     selectSourcePlaceholder = 'Select source...';
     selectTargetPlaceholder = 'Select target...';
   }
@@ -72,13 +68,17 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
               <>
                 <GridItem span={5} className={spacing.pbSm}>
                   <label className="pf-c-form__label">
-                    <span className="pf-c-form__label-text">{sourceHeadingText}</span>
+                    <span className="pf-c-form__label-text">
+                      {getMappingSourceTitle(mappingType)}
+                    </span>
                   </label>
                 </GridItem>
                 <GridItem span={1} />
                 <GridItem span={5} className={spacing.pbSm}>
                   <label className="pf-c-form__label">
-                    <span className="pf-c-form__label-text">{targetHeadingText}</span>
+                    <span className="pf-c-form__label-text">
+                      {getMappingTargetTitle(mappingType)}
+                    </span>
                   </label>
                 </GridItem>
                 <GridItem span={1} />

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -3,7 +3,6 @@ import { Button, TextContent, Text, Grid, GridItem, Bullseye, Flex } from '@patt
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { MappingType, MappingSource, MappingTarget } from '../../types';
-import { IVMwareNetwork, IVMwareDatastore } from '@app/Providers/types';
 import LineArrow from '@app/common/components/LineArrow/LineArrow';
 import MappingSourceSelect from './MappingSourceSelect';
 import MappingTargetSelect from './MappingTargetSelect';

--- a/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -3,6 +3,7 @@ import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSele
 import { ICNVNetwork } from '@app/Providers/types';
 import { MappingTarget, MappingType } from '@app/Mappings/types';
 import { IMappingBuilderItem } from './MappingBuilder';
+import { getMappingTargetName } from '../helpers';
 
 interface IMappingTargetSelectProps {
   id: string;
@@ -31,15 +32,7 @@ const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectProps> = 
 
   const targetOptions: OptionWithValue<MappingTarget>[] = availableTargets.map((target) => ({
     value: target,
-    toString: () => {
-      if (mappingType === MappingType.Network) {
-        return (target as ICNVNetwork).name;
-      }
-      if (mappingType === MappingType.Storage) {
-        return target as string;
-      }
-      return '';
-    },
+    toString: () => getMappingTargetName(target, mappingType),
   }));
   const selectedOption = targetOptions.find(
     (option: OptionWithValue<MappingTarget>) => option.value === builderItems[itemIndex].target

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -9,9 +9,7 @@ import {
 } from '../../types';
 import { IMappingBuilderItem } from './MappingBuilder';
 import { IVMwareProvider, ICNVProvider } from '@app/Providers/types';
-
-export const getSourceById = (sources: MappingSource[], id: string): MappingSource | undefined =>
-  sources.find((source) => source.id === id);
+import { getMappingSourceById } from '../helpers';
 
 export const getBuilderItemsFromMapping = (
   mapping: Mapping,
@@ -19,7 +17,7 @@ export const getBuilderItemsFromMapping = (
 ): IMappingBuilderItem[] =>
   (mapping.items as (INetworkMappingItem | IStorageMappingItem)[])
     .map((item: MappingItem) => {
-      const source = getSourceById(allSources, item.source.id);
+      const source = getMappingSourceById(allSources, item.source.id);
       if (source) {
         return { source, target: item.target } as IMappingBuilderItem;
       }

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -1,12 +1,4 @@
-import {
-  MappingSource,
-  Mapping,
-  MappingItem,
-  MappingType,
-  MappingTarget,
-  INetworkMappingItem,
-  IStorageMappingItem,
-} from '../../types';
+import { MappingSource, Mapping, MappingItem, MappingType, MappingTarget } from '../../types';
 import { IMappingBuilderItem } from './MappingBuilder';
 import { IVMwareProvider, ICNVProvider } from '@app/Providers/types';
 import { getMappingSourceById } from '../helpers';
@@ -15,7 +7,7 @@ export const getBuilderItemsFromMapping = (
   mapping: Mapping,
   allSources: MappingSource[]
 ): IMappingBuilderItem[] =>
-  (mapping.items as (INetworkMappingItem | IStorageMappingItem)[])
+  (mapping.items as MappingItem[])
     .map((item: MappingItem) => {
       const source = getMappingSourceById(allSources, item.source.id);
       if (source) {

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
@@ -1,9 +1,3 @@
-.pf-c-content h2.mapping-view-box-heading {
-  font-weight: var(--pf-c-form__label-text--FontWeight);
-  font-size: var(--pf-c-form__label--FontSize);
-  line-height: var(--pf-c-form__label--LineHeight);
-}
-
 .mapping-view-box {
   border: 1px solid #000000;
 }

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
@@ -1,0 +1,13 @@
+.pf-c-content h2.mapping-view-box-heading {
+  font-weight: var(--pf-c-form__label-text--FontWeight);
+  font-size: var(--pf-c-form__label--FontSize);
+  line-height: var(--pf-c-form__label--LineHeight);
+}
+
+.mapping-view-box {
+  border: 1px solid #000000;
+}
+
+.mapping-view-arrow-cell {
+  padding-top: 12px;
+}

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -13,19 +13,19 @@ import { groupMappingItemsByTarget } from './helpers';
 
 import './MappingDetailView.css';
 
-interface IMappingViewerProps {
+interface IMappingDetailViewProps {
   mappingType: MappingType;
   mapping: Mapping;
   availableSources: MappingSource[];
   className: string;
 }
 
-const MappingViewer: React.FunctionComponent<IMappingViewerProps> = ({
+const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
   mappingType,
   mapping,
   availableSources,
   className,
-}: IMappingViewerProps) => {
+}: IMappingDetailViewProps) => {
   const mappingItemGroups = groupMappingItemsByTarget(mapping.items, mappingType);
   return (
     <div className={className}>
@@ -69,4 +69,4 @@ const MappingViewer: React.FunctionComponent<IMappingViewerProps> = ({
   );
 };
 
-export default MappingViewer;
+export default MappingDetailView;

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { Mapping, MappingType } from '@app/Mappings/types';
+import LineArrow from '@app/common/components/LineArrow';
+import './MappingDetailView.css';
+
+interface IMappingViewerProps {
+  mappingType: MappingType;
+  mapping: Mapping;
+  className: string;
+}
+
+const MappingViewer: React.FunctionComponent<IMappingViewerProps> = ({
+  mappingType,
+  mapping,
+  className,
+}: IMappingViewerProps) => {
+  return (
+    <div className={className}>
+      <Grid>
+        <GridItem span={5} className={spacing.pbSm}>
+          <TextContent>
+            <Text component="h2" className="mapping-view-box-heading">
+              TODO: source heading
+            </Text>
+          </TextContent>
+        </GridItem>
+        <GridItem span={2}></GridItem>
+        <GridItem span={5} className={spacing.pbSm}>
+          <TextContent>
+            <Text component="h2" className="mapping-view-box-heading">
+              TODO: target heading
+            </Text>
+          </TextContent>
+        </GridItem>
+      </Grid>
+      <Grid>
+        <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
+          <ul>
+            <li>TODO: source 1</li>
+            <li>TODO: source 2</li>
+            <li>TODO: source 3</li>
+          </ul>
+        </GridItem>
+        <GridItem span={2} className="mapping-view-arrow-cell">
+          <LineArrow />
+        </GridItem>
+        <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
+          TODO: target name
+        </GridItem>
+      </Grid>
+    </div>
+  );
+};
+
+export default MappingViewer;

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -1,55 +1,70 @@
 import * as React from 'react';
-import { Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
+import { Grid, GridItem, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { Mapping, MappingType } from '@app/Mappings/types';
+import { Mapping, MappingSource, MappingType } from '@app/Mappings/types';
 import LineArrow from '@app/common/components/LineArrow';
+import {
+  getMappingSourceById,
+  getMappingSourceTitle,
+  getMappingTargetName,
+  getMappingTargetTitle,
+} from '../helpers';
+import { groupMappingItemsByTarget } from './helpers';
+
 import './MappingDetailView.css';
 
 interface IMappingViewerProps {
   mappingType: MappingType;
   mapping: Mapping;
+  availableSources: MappingSource[];
   className: string;
 }
 
 const MappingViewer: React.FunctionComponent<IMappingViewerProps> = ({
   mappingType,
   mapping,
+  availableSources,
   className,
 }: IMappingViewerProps) => {
+  const mappingItemGroups = groupMappingItemsByTarget(mapping.items, mappingType);
   return (
     <div className={className}>
       <Grid>
         <GridItem span={5} className={spacing.pbSm}>
-          <TextContent>
-            <Text component="h2" className="mapping-view-box-heading">
-              TODO: source heading
-            </Text>
-          </TextContent>
+          <Title size="md" headingLevel="h2">
+            {getMappingSourceTitle(mappingType)}
+          </Title>
         </GridItem>
         <GridItem span={2}></GridItem>
         <GridItem span={5} className={spacing.pbSm}>
-          <TextContent>
-            <Text component="h2" className="mapping-view-box-heading">
-              TODO: target heading
-            </Text>
-          </TextContent>
+          <Title size="md" headingLevel="h2">
+            {getMappingTargetTitle(mappingType)}
+          </Title>
         </GridItem>
       </Grid>
-      <Grid>
-        <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
-          <ul>
-            <li>TODO: source 1</li>
-            <li>TODO: source 2</li>
-            <li>TODO: source 3</li>
-          </ul>
-        </GridItem>
-        <GridItem span={2} className="mapping-view-arrow-cell">
-          <LineArrow />
-        </GridItem>
-        <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
-          TODO: target name
-        </GridItem>
-      </Grid>
+      {mappingItemGroups.map((items, index) => {
+        const targetName = getMappingTargetName(items[0].target, mappingType);
+        const isLastGroup = index === mappingItemGroups.length - 1;
+        return (
+          <Grid key={targetName} className={!isLastGroup ? spacing.mbLg : ''}>
+            <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
+              <ul>
+                {items.map((item) => {
+                  const source = getMappingSourceById(availableSources, item.source.id);
+                  const sourceName = source ? source.name : '';
+                  return <li key={sourceName}>{sourceName}</li>;
+                })}
+              </ul>
+            </GridItem>
+            <GridItem span={2} className="mapping-view-arrow-cell">
+              <LineArrow />
+            </GridItem>
+            <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
+              {targetName}
+            </GridItem>
+          </Grid>
+        );
+      })}
     </div>
   );
 };

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -1,0 +1,15 @@
+import { INetworkMappingItem, IStorageMappingItem, MappingType } from '@app/Mappings/types';
+import { ICNVNetwork } from '@app/Providers/types';
+import { getMappingTargetName } from '../helpers';
+
+export const groupMappingItemsByTarget = (
+  mappingItems: (IStorageMappingItem | INetworkMappingItem)[],
+  mappingType: MappingType
+): (IStorageMappingItem | INetworkMappingItem)[][] => {
+  const targetNames: (ICNVNetwork | string)[] = Array.from(
+    new Set(mappingItems.map((item) => getMappingTargetName(item.target, mappingType)))
+  );
+  return targetNames.map((targetName) =>
+    mappingItems.filter((item) => getMappingTargetName(item.target, mappingType) === targetName)
+  );
+};

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -1,12 +1,11 @@
 import { INetworkMappingItem, IStorageMappingItem, MappingType } from '@app/Mappings/types';
-import { ICNVNetwork } from '@app/Providers/types';
 import { getMappingTargetName } from '../helpers';
 
 export const groupMappingItemsByTarget = (
   mappingItems: (IStorageMappingItem | INetworkMappingItem)[],
   mappingType: MappingType
 ): (IStorageMappingItem | INetworkMappingItem)[][] => {
-  const targetNames: (ICNVNetwork | string)[] = Array.from(
+  const targetNames: string[] = Array.from(
     new Set(mappingItems.map((item) => getMappingTargetName(item.target, mappingType)))
   );
   return targetNames.map((targetName) =>

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -1,10 +1,10 @@
-import { INetworkMappingItem, IStorageMappingItem, MappingType } from '@app/Mappings/types';
+import { MappingItem, MappingType } from '@app/Mappings/types';
 import { getMappingTargetName } from '../helpers';
 
 export const groupMappingItemsByTarget = (
-  mappingItems: (IStorageMappingItem | INetworkMappingItem)[],
+  mappingItems: MappingItem[],
   mappingType: MappingType
-): (IStorageMappingItem | INetworkMappingItem)[][] => {
+): MappingItem[][] => {
   const targetNames: string[] = Array.from(
     new Set(mappingItems.map((item) => getMappingTargetName(item.target, mappingType)))
   );

--- a/src/app/Mappings/components/MappingDetailView/index.ts
+++ b/src/app/Mappings/components/MappingDetailView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MappingDetailView';

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -15,9 +15,11 @@ import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
-import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
+import { Mapping, MappingType, INetworkMapping, IStorageMapping, MappingSource } from '../types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
+import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/Providers/mocks/datastores.mock';
+import { MOCK_VMWARE_NETWORKS_BY_PROVIDER } from '@app/Providers/mocks/networks.mock';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
@@ -61,6 +63,15 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
 
   const rows: IRow[] = [];
   currentPageItems.forEach((mapping: Mapping) => {
+    // TODO use the right thing from redux here instead of mock data
+    let availableSources: MappingSource[] = [];
+    if (mappingType === MappingType.Network) {
+      availableSources = MOCK_VMWARE_NETWORKS_BY_PROVIDER[mapping.provider.source.name];
+    }
+    if (mappingType === MappingType.Storage) {
+      availableSources = MOCK_VMWARE_DATASTORES_BY_PROVIDER[mapping.provider.source.name];
+    }
+
     const { name, provider, items } = mapping;
     const isExpanded = isMappingExpanded(mapping);
     rows.push({
@@ -97,6 +108,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
               <MappingDetailView
                 mappingType={mappingType}
                 mapping={mapping}
+                availableSources={availableSources}
                 className={spacing.mLg}
               />
             ),

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
 import { Level, LevelItem, Button, Pagination } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   Table,
   TableHeader,
@@ -15,11 +15,13 @@ import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
+import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
+import MappingDetailView from './MappingDetailView';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
-  mappingType: string;
+  mappingType: MappingType;
   toggleAddEditModal: () => void;
 }
 
@@ -30,7 +32,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
 }: IMappingsTableProps) => {
   const getSortValues = (mapping: Mapping) => {
     const { name, provider } = mapping;
-    return [name, provider.source.name, provider.target.name, ''];
+    return ['', name, provider.source.name, provider.target.name, ''];
   };
 
   const { sortBy, onSort, sortedItems } = useSortState(mappings, getSortValues);
@@ -38,9 +40,8 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   React.useEffect(() => setPageNumber(1), [sortBy, setPageNumber]);
 
   const {
-    selectedItems: expandedMappings,
     toggleItemSelected: toggleMappingExpanded,
-    isItemSelected,
+    isItemSelected: isMappingExpanded,
   } = useSelectionState<Mapping>({
     items: sortedItems,
     isEqual: (a, b) => a.name === b.name,
@@ -51,7 +52,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     { title: 'Source provider', transforms: [sortable] },
     { title: 'Target provider', transforms: [sortable] },
     {
-      title: <>{mappingType === MappingType.Network ? 'Network mappings' : 'Storage mappings'}</>,
+      title: mappingType === MappingType.Network ? 'Network mappings' : 'Storage mappings',
       transforms: [sortable],
     },
     { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
@@ -61,8 +62,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   const rows: IRow[] = [];
   currentPageItems.forEach((mapping: Mapping) => {
     const { name, provider, items } = mapping;
-    //TODO: update to use isItemSelected from useSelectionState hook when we start using redux
-    const isExpanded = isItemSelected(mapping);
+    const isExpanded = isMappingExpanded(mapping);
     rows.push({
       meta: { mapping },
       isOpen: isExpanded,
@@ -90,15 +90,17 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     if (isExpanded) {
       rows.push({
         parent: rows.length - 1,
+        fullWidth: true,
         cells: [
           {
             title: (
-              <div>
-                TODO: mapping details table
-                {/* <MappingDetailsTable {...props} /> */}
-              </div>
+              <MappingDetailView
+                mappingType={mappingType}
+                mapping={mapping}
+                className={spacing.mLg}
+              />
             ),
-            props: { colSpan: columns.length, className: tableStyles.modifiers.noPadding },
+            props: { colSpan: columns.length + 1, className: tableStyles.modifiers.noPadding },
           },
         ],
       });

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -14,7 +14,6 @@ import {
 import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import { NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
 import { Mapping, MappingType, INetworkMapping, IStorageMapping, MappingSource } from '../types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
@@ -34,7 +33,13 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
 }: IMappingsTableProps) => {
   const getSortValues = (mapping: Mapping) => {
     const { name, provider } = mapping;
-    return ['', name, provider.source.name, provider.target.name, ''];
+    return [
+      '', // Expand control column
+      name,
+      provider.source.name,
+      provider.target.name,
+      '', // Action column
+    ];
   };
 
   const { sortBy, onSort, sortedItems } = useSortState(mappings, getSortValues);
@@ -53,12 +58,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     { title: 'Name', transforms: [sortable], cellFormatters: [expandable] },
     { title: 'Source provider', transforms: [sortable] },
     { title: 'Target provider', transforms: [sortable] },
-    {
-      title: mappingType === MappingType.Network ? 'Network mappings' : 'Storage mappings',
-      transforms: [sortable],
-    },
     { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
-    { title: '' },
   ];
 
   const rows: IRow[] = [];
@@ -72,7 +72,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
       availableSources = MOCK_VMWARE_DATASTORES_BY_PROVIDER[mapping.provider.source.name];
     }
 
-    const { name, provider, items } = mapping;
+    const { name, provider } = mapping;
     const isExpanded = isMappingExpanded(mapping);
     rows.push({
       meta: { mapping },
@@ -81,18 +81,6 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         name,
         provider.source?.name,
         provider.target?.name,
-        {
-          title: (
-            <>
-              {mappingType === MappingType.Network ? (
-                <NetworkIcon key="hosts-icon" />
-              ) : (
-                <DatabaseIcon key="storage-icon" />
-              )}{' '}
-              {items ? items.length : 0}
-            </>
-          ),
-        },
         {
           title: <MappingsActionsDropdown />,
         },

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -1,12 +1,5 @@
 import * as React from 'react';
-import {
-  Mapping,
-  MappingType,
-  INetworkMapping,
-  IStorageMapping,
-  INetworkMappingItem,
-  IStorageMappingItem,
-} from '../types';
+import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '../types';
 import { Level, LevelItem, Button, Pagination } from '@patternfly/react-core';
 import {
   Table,
@@ -20,12 +13,8 @@ import {
 } from '@patternfly/react-table';
 import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
-import { IVMwareProvider } from '@app/Providers/types';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import { OutlinedHddIcon, NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
-import ProviderStatus from '@app/Providers/components/ProvidersTable/ProviderStatus';
-import VMwareProviderActionsDropdown from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderActionsDropdown';
-import VMwareProviderHostsTable from '@app/Providers/components/ProvidersTable/VMware/VMwareProviderHostsTable';
+import { NetworkIcon, DatabaseIcon } from '@patternfly/react-icons';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 
 interface IMappingsTableProps {

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -1,0 +1,37 @@
+import { ICNVNetwork } from '@app/Providers/types';
+import { MappingSource, MappingTarget, MappingType } from '../types';
+
+export const getMappingSourceById = (
+  sources: MappingSource[],
+  id: string
+): MappingSource | undefined => sources.find((source) => source.id === id);
+
+export const getMappingSourceTitle = (mappingType: MappingType): string => {
+  if (mappingType === MappingType.Network) {
+    return 'Source networks';
+  }
+  if (mappingType === MappingType.Storage) {
+    return 'Source datastores';
+  }
+  return '';
+};
+
+export const getMappingTargetTitle = (mappingType: MappingType): string => {
+  if (mappingType === MappingType.Network) {
+    return 'Target networks';
+  }
+  if (mappingType === MappingType.Storage) {
+    return 'Target storage classes';
+  }
+  return '';
+};
+
+export const getMappingTargetName = (target: MappingTarget, mappingType: MappingType): string => {
+  if (mappingType === MappingType.Network) {
+    return (target as ICNVNetwork).name;
+  }
+  if (mappingType === MappingType.Storage) {
+    return target as string;
+  }
+  return '';
+};

--- a/src/app/Mappings/mocks/helpers.ts
+++ b/src/app/Mappings/mocks/helpers.ts
@@ -1,7 +1,7 @@
 import { MappingType, Mapping } from '../types';
 
 // TODO: This is a temporary function designed for testing the mappings table. Remove when we wire up Redux & api
-export const updateMockStorage = (generatedMapping: Mapping) => {
+export const updateMockStorage = (generatedMapping: Mapping): void => {
   const { name: mappingName, provider, type: mappingType, items } = generatedMapping;
   const mappingsKey =
     mappingType === MappingType.Network ? 'networkMappingsObject' : 'storageMappingsObject';
@@ -19,6 +19,7 @@ export const updateMockStorage = (generatedMapping: Mapping) => {
             name: provider.source.name,
           },
         },
+        items,
       },
       ...(currentMappings?.mappings ? currentMappings.mappings : []),
     ],
@@ -26,7 +27,7 @@ export const updateMockStorage = (generatedMapping: Mapping) => {
   localStorage.setItem(mappingsKey, JSON.stringify(mockMappings));
 };
 
-export const fetchMockStorage = (mappingType: string) => {
+export const fetchMockStorage = (mappingType: string): Mapping[] => {
   const mappingsKey =
     mappingType === MappingType.Network ? 'networkMappingsObject' : 'storageMappingsObject';
   const mappingsItem = localStorage.getItem(mappingsKey);

--- a/src/app/common/components/LineArrow/index.ts
+++ b/src/app/common/components/LineArrow/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LineArrow';


### PR DESCRIPTION
Closes #43.

This implements the `MappingDetailView` component, which uses the same box-and-arrow layout from the `MappingBuilder` but in a read-only form with sources grouped by target.

Originally I was planning to use MappingBuilder with a prop to disable the editing controls, but this turned out to be different enough that it seemed cleaner to make it a separate component.

This PR adds it to the mappings table, we should also use it in the results step of the plan wizard in a future PR.

<img width="1126" alt="Screen Shot 2020-09-14 at 6 34 54 PM" src="https://user-images.githubusercontent.com/811963/93145333-0e26df80-f6ba-11ea-845f-9b20a6eb6203.png">
