### PR TITLE
Add useStorageClassesQuery, combine with mocks in useMappingResourceQueries, factor out helpers, load storage classes from API

### DIFF
--- a/src/app/Mappings/Network/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/Network/NetworkMappingsPage.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 import {
   PageSection,
   Title,
-  Bullseye,
   EmptyState,
-  Spinner,
   EmptyStateIcon,
   EmptyStateBody,
   Button,
@@ -17,6 +15,7 @@ import { INetworkMapping, MappingType } from '@app/queries/types';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
 import { fetchMockStorage } from '@app/queries/mocks/helpers';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 const isFetchingInitialNetworkMappings = false; // Fetching for the first time, not polling
 
@@ -42,14 +41,7 @@ const NetworkMappingsPage: React.FunctionComponent = () => {
       </PageSection>
       <PageSection>
         {isFetchingInitialNetworkMappings ? (
-          <Bullseye>
-            <EmptyState>
-              <div className="pf-c-empty-state__icon">
-                <Spinner size="xl" />
-              </div>
-              <Title headingLevel="h2">Loading...</Title>
-            </EmptyState>
-          </Bullseye>
+          <LoadingEmptyState />
         ) : (
           <Card>
             <CardBody>

--- a/src/app/Mappings/Storage/StorageMappingsPage.tsx
+++ b/src/app/Mappings/Storage/StorageMappingsPage.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 import {
   PageSection,
   Title,
-  Bullseye,
   EmptyState,
-  Spinner,
   Card,
   CardBody,
   EmptyStateIcon,
@@ -17,6 +15,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import MappingsTable from '../components/MappingsTable';
 import AddEditMappingModal from '../components/AddEditMappingModal';
 import { fetchMockStorage } from '@app/queries/mocks/helpers';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 const isFetchingInitialStorageMappings = false; // Fetching for the first time, not polling
 
@@ -42,14 +41,7 @@ const StorageMappingsPage: React.FunctionComponent = () => {
       </PageSection>
       <PageSection>
         {isFetchingInitialStorageMappings ? (
-          <Bullseye>
-            <EmptyState>
-              <div className="pf-c-empty-state__icon">
-                <Spinner size="xl" />
-              </div>
-              <Title headingLevel="h2">Loading...</Title>
-            </EmptyState>
-          </Bullseye>
+          <LoadingEmptyState />
         ) : (
           <Card>
             <CardBody>

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -33,6 +33,7 @@ import { useProvidersQuery } from '@app/queries';
 import { updateMockStorage } from '@app/queries/mocks/helpers';
 import './AddEditMappingModal.css';
 import { usePausedPollingEffect } from '@app/common/context';
+import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from '@app/queries/mocks/storageClasses.mock';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -41,7 +42,7 @@ interface IAddEditMappingModalProps {
 }
 
 // TODO move these to a dependent query from providers
-const MOCK_STORAGE_CLASSES = ['gold', 'silver', 'bronze'];
+const MOCK_STORAGE_CLASSES = MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
 
 const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = ({
   title,

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -102,7 +102,6 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
             <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
               <MappingTargetSelect
                 id={`mapping-target-for-${key}`}
-                mappingType={mappingType}
                 builderItems={builderItems}
                 itemIndex={itemIndex}
                 setBuilderItems={setBuilderItems}

--- a/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import { MappingTarget, MappingType } from '@app/queries/types';
+import { MappingTarget } from '@app/queries/types';
 import { IMappingBuilderItem } from './MappingBuilder';
-import { getMappingTargetName } from '../helpers';
 
 interface IMappingTargetSelectProps {
   id: string;
-  mappingType: MappingType;
   builderItems: IMappingBuilderItem[];
   itemIndex: number;
   setBuilderItems: (items: IMappingBuilderItem[]) => void;
@@ -16,7 +14,6 @@ interface IMappingTargetSelectProps {
 
 const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectProps> = ({
   id,
-  mappingType,
   builderItems,
   itemIndex,
   setBuilderItems,
@@ -31,7 +28,7 @@ const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectProps> = 
 
   const targetOptions: OptionWithValue<MappingTarget>[] = availableTargets.map((target) => ({
     value: target,
-    toString: () => getMappingTargetName(target, mappingType),
+    toString: () => target.name,
   }));
   const selectedOption = targetOptions.find(
     (option: OptionWithValue<MappingTarget>) => option.value === builderItems[itemIndex].target

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -44,7 +44,7 @@ export const getMappingFromBuilderItems = ({
       if (item.source && item.target) {
         return {
           source: { id: item.source.id },
-          target: item.target as MappingTarget,
+          target: item.target.name as MappingItem['target'],
         };
       }
       return null;

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -54,14 +54,8 @@ export const getMappingFromBuilderItems = ({
     type: mappingType,
     name: mappingName,
     provider: {
-      source: {
-        type: sourceProvider.type,
-        name: sourceProvider.name,
-      },
-      target: {
-        type: targetProvider.type,
-        name: targetProvider.name,
-      },
+      source: sourceProvider,
+      target: targetProvider,
     },
     items,
   } as Mapping;

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -3,7 +3,6 @@ import {
   Mapping,
   MappingItem,
   MappingType,
-  MappingTarget,
   IVMwareProvider,
   IOpenShiftProvider,
 } from '@app/queries/types';
@@ -44,7 +43,7 @@ export const getMappingFromBuilderItems = ({
       if (item.source && item.target) {
         return {
           source: { id: item.source.id },
-          target: item.target.name as MappingItem['target'],
+          target: item.target,
         };
       }
       return null;

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -3,12 +3,7 @@ import { Alert, Grid, GridItem, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Mapping, MappingType } from '@app/queries/types';
 import LineArrow from '@app/common/components/LineArrow';
-import {
-  getMappingSourceById,
-  getMappingSourceTitle,
-  getMappingItemTargetName,
-  getMappingTargetTitle,
-} from '../helpers';
+import { getMappingSourceById, getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
 import { groupMappingItemsByTarget } from './helpers';
 
 import './MappingDetailView.css';
@@ -39,11 +34,7 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
     return <Alert className={className} variant="danger" title="Error loading mapping resources" />;
   }
 
-  const mappingItemGroups = groupMappingItemsByTarget(
-    mapping.items,
-    mappingType,
-    mappingResourceQueries.availableTargets
-  );
+  const mappingItemGroups = groupMappingItemsByTarget(mapping.items);
   return (
     <div className={className}>
       <Grid>
@@ -60,11 +51,7 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
         </GridItem>
       </Grid>
       {mappingItemGroups.map((items, index) => {
-        const targetName = getMappingItemTargetName(
-          items[0].target,
-          mappingType,
-          mappingResourceQueries.availableTargets
-        );
+        const targetName = items[0].target.name;
         const isLastGroup = index === mappingItemGroups.length - 1;
         return (
           <Grid key={targetName} className={!isLastGroup ? spacing.mbLg : ''}>

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Grid, GridItem, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { Mapping, MappingSource, MappingType } from '@app/queries/types';
+import { Mapping, MappingSource, MappingTarget, MappingType } from '@app/queries/types';
 import LineArrow from '@app/common/components/LineArrow';
 import {
   getMappingSourceById,
   getMappingSourceTitle,
-  getMappingTargetName,
+  getMappingItemTargetName,
   getMappingTargetTitle,
 } from '../helpers';
 import { groupMappingItemsByTarget } from './helpers';
@@ -17,6 +17,7 @@ interface IMappingDetailViewProps {
   mappingType: MappingType;
   mapping: Mapping;
   availableSources: MappingSource[];
+  availableTargets: MappingTarget[];
   className: string;
 }
 
@@ -24,9 +25,10 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
   mappingType,
   mapping,
   availableSources,
+  availableTargets,
   className,
 }: IMappingDetailViewProps) => {
-  const mappingItemGroups = groupMappingItemsByTarget(mapping.items, mappingType);
+  const mappingItemGroups = groupMappingItemsByTarget(mapping.items, mappingType, availableTargets);
   return (
     <div className={className}>
       <Grid>
@@ -43,7 +45,7 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
         </GridItem>
       </Grid>
       {mappingItemGroups.map((items, index) => {
-        const targetName = getMappingTargetName(items[0].target, mappingType);
+        const targetName = getMappingItemTargetName(items[0].target, mappingType, availableTargets);
         const isLastGroup = index === mappingItemGroups.length - 1;
         return (
           <Grid key={targetName} className={!isLastGroup ? spacing.mbLg : ''}>

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -1,14 +1,21 @@
-import { MappingItem, MappingType } from '@app/queries/types';
-import { getMappingTargetName } from '../helpers';
+import { MappingItem, MappingTarget, MappingType } from '@app/queries/types';
+import { getMappingItemTargetName } from '../helpers';
 
 export const groupMappingItemsByTarget = (
   mappingItems: MappingItem[],
-  mappingType: MappingType
+  mappingType: MappingType,
+  availableTargets: MappingTarget[]
 ): MappingItem[][] => {
   const targetNames: string[] = Array.from(
-    new Set(mappingItems.map((item) => getMappingTargetName(item.target, mappingType)))
+    new Set(
+      mappingItems.map((item) =>
+        getMappingItemTargetName(item.target, mappingType, availableTargets)
+      )
+    )
   );
   return targetNames.map((targetName) =>
-    mappingItems.filter((item) => getMappingTargetName(item.target, mappingType) === targetName)
+    mappingItems.filter(
+      (item) => getMappingItemTargetName(item.target, mappingType, availableTargets) === targetName
+    )
   );
 };

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -1,21 +1,8 @@
-import { MappingItem, MappingTarget, MappingType } from '@app/queries/types';
-import { getMappingItemTargetName } from '../helpers';
+import { MappingItem } from '@app/queries/types';
 
-export const groupMappingItemsByTarget = (
-  mappingItems: MappingItem[],
-  mappingType: MappingType,
-  availableTargets: MappingTarget[]
-): MappingItem[][] => {
-  const targetNames: string[] = Array.from(
-    new Set(
-      mappingItems.map((item) =>
-        getMappingItemTargetName(item.target, mappingType, availableTargets)
-      )
-    )
-  );
+export const groupMappingItemsByTarget = (mappingItems: MappingItem[]): MappingItem[][] => {
+  const targetNames: string[] = Array.from(new Set(mappingItems.map((item) => item.target.name)));
   return targetNames.map((targetName) =>
-    mappingItems.filter(
-      (item) => getMappingItemTargetName(item.target, mappingType, availableTargets) === targetName
-    )
+    mappingItems.filter((item) => item.target.name === targetName)
   );
 };

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -11,25 +11,12 @@ import {
   IRow,
   expandable,
 } from '@patternfly/react-table';
+import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
-import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import {
-  Mapping,
-  MappingType,
-  INetworkMapping,
-  IStorageMapping,
-  MappingSource,
-  MappingTarget,
-} from '@app/queries/types';
+import { Mapping, MappingType, INetworkMapping, IStorageMapping } from '@app/queries/types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
-import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/queries/mocks/datastores.mock';
-import {
-  MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER,
-  MOCK_VMWARE_NETWORKS_BY_PROVIDER,
-} from '@app/queries/mocks/networks.mock';
-import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from '@app/queries/mocks/storageClasses.mock';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
@@ -74,18 +61,6 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
 
   const rows: IRow[] = [];
   currentPageItems.forEach((mapping: Mapping) => {
-    // TODO use the right thing from react-query here instead of mock data
-    let availableSources: MappingSource[] = [];
-    let availableTargets: MappingTarget[] = [];
-    if (mappingType === MappingType.Network) {
-      availableSources = MOCK_VMWARE_NETWORKS_BY_PROVIDER.VCenter1;
-      availableTargets = MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER.OCPv_1;
-    }
-    if (mappingType === MappingType.Storage) {
-      availableSources = MOCK_VMWARE_DATASTORES_BY_PROVIDER.VCenter1;
-      availableTargets = MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
-    }
-
     const { name, provider } = mapping;
     const isExpanded = isMappingExpanded(mapping);
     rows.push({
@@ -110,8 +85,6 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
               <MappingDetailView
                 mappingType={mappingType}
                 mapping={mapping}
-                availableSources={availableSources}
-                availableTargets={availableTargets}
                 className={spacing.mLg}
               />
             ),

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -20,11 +20,16 @@ import {
   INetworkMapping,
   IStorageMapping,
   MappingSource,
+  MappingTarget,
 } from '@app/queries/types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
 import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from '@app/queries/mocks/datastores.mock';
-import { MOCK_VMWARE_NETWORKS_BY_PROVIDER } from '@app/queries/mocks/networks.mock';
+import {
+  MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER,
+  MOCK_VMWARE_NETWORKS_BY_PROVIDER,
+} from '@app/queries/mocks/networks.mock';
+import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from '@app/queries/mocks/storageClasses.mock';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
@@ -71,11 +76,14 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   currentPageItems.forEach((mapping: Mapping) => {
     // TODO use the right thing from react-query here instead of mock data
     let availableSources: MappingSource[] = [];
+    let availableTargets: MappingTarget[] = [];
     if (mappingType === MappingType.Network) {
       availableSources = MOCK_VMWARE_NETWORKS_BY_PROVIDER.VCenter1;
+      availableTargets = MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER.OCPv_1;
     }
     if (mappingType === MappingType.Storage) {
       availableSources = MOCK_VMWARE_DATASTORES_BY_PROVIDER.VCenter1;
+      availableTargets = MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
     }
 
     const { name, provider } = mapping;
@@ -103,6 +111,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
                 mappingType={mappingType}
                 mapping={mapping}
                 availableSources={availableSources}
+                availableTargets={availableTargets}
                 className={spacing.mLg}
               />
             ),

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -1,11 +1,4 @@
-import {
-  IOpenShiftNetwork,
-  IStorageClass,
-  MappingItem,
-  MappingSource,
-  MappingTarget,
-  MappingType,
-} from '@app/queries/types';
+import { MappingSource, MappingType } from '@app/queries/types';
 
 export const getMappingSourceById = (
   sources: MappingSource[],
@@ -28,24 +21,6 @@ export const getMappingTargetTitle = (mappingType: MappingType): string => {
   }
   if (mappingType === MappingType.Storage) {
     return 'Target storage classes';
-  }
-  return '';
-};
-
-export const getMappingItemTargetName = (
-  target: MappingItem['target'],
-  mappingType: MappingType,
-  availableTargets: MappingTarget[]
-): string => {
-  if (mappingType === MappingType.Network) {
-    return (target as IOpenShiftNetwork).name;
-  }
-  if (mappingType === MappingType.Storage) {
-    return (
-      (availableTargets as IStorageClass[]).find(
-        (storageClass) => storageClass.name === (target as string)
-      )?.name || ''
-    );
   }
   return '';
 };

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -1,4 +1,11 @@
-import { IOpenShiftNetwork, MappingSource, MappingTarget, MappingType } from '@app/queries/types';
+import {
+  IOpenShiftNetwork,
+  IStorageClass,
+  MappingItem,
+  MappingSource,
+  MappingTarget,
+  MappingType,
+} from '@app/queries/types';
 
 export const getMappingSourceById = (
   sources: MappingSource[],
@@ -25,12 +32,20 @@ export const getMappingTargetTitle = (mappingType: MappingType): string => {
   return '';
 };
 
-export const getMappingTargetName = (target: MappingTarget, mappingType: MappingType): string => {
+export const getMappingItemTargetName = (
+  target: MappingItem['target'],
+  mappingType: MappingType,
+  availableTargets: MappingTarget[]
+): string => {
   if (mappingType === MappingType.Network) {
     return (target as IOpenShiftNetwork).name;
   }
   if (mappingType === MappingType.Storage) {
-    return target as string;
+    return (
+      (availableTargets as IStorageClass[]).find(
+        (storageClass) => storageClass.name === (target as string)
+      )?.name || ''
+    );
   }
   return '';
 };

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -55,7 +55,7 @@ const PlansPage: React.FunctionComponent = () => {
       <PageSection>
         {providersQuery.isLoading || isFetchingInitialPlans ? (
           <LoadingEmptyState />
-        ) : providersQuery.status === 'error' ? (
+        ) : providersQuery.isError ? (
           <Alert variant="danger" title="Error loading providers" />
         ) : (
           <Card>

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -8,8 +8,6 @@ import {
   EmptyStateBody,
   Title,
   Button,
-  Bullseye,
-  Spinner,
   Alert,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
@@ -23,6 +21,7 @@ import PlanWizard from './components/Wizard/PlanWizard';
 
 // TODO replace these with real data from react-query
 import { MOCK_PLANS } from '@app/queries/mocks/plans.mock';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 const isFetchingInitialPlans = false; // Fetching for the first time, not polling
 const migplans = MOCK_PLANS;
@@ -55,14 +54,7 @@ const PlansPage: React.FunctionComponent = () => {
       </PageSection>
       <PageSection>
         {providersQuery.isLoading || isFetchingInitialPlans ? (
-          <Bullseye>
-            <EmptyState variant="large">
-              <div className="pf-c-empty-state__icon">
-                <Spinner size="xl" />
-              </div>
-              <Title headingLevel="h2">Loading...</Title>
-            </EmptyState>
-          </Bullseye>
+          <LoadingEmptyState />
         ) : providersQuery.status === 'error' ? (
           <Alert variant="danger" title="Error loading providers" />
         ) : (

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -8,14 +8,7 @@ import Review from './Review';
 import { MappingType, IOpenShiftProvider, IVMwareProvider } from '@app/queries/types';
 import { MOCK_VMS } from '@app/queries/mocks/vms.mock';
 import MappingForm from './MappingForm';
-import {
-  MOCK_STORAGE_MAPPINGS,
-  MOCK_STORAGE_MAPPING_SOURCES,
-  MOCK_STORAGE_MAPPING_TARGETS,
-  MOCK_NETWORK_MAPPINGS,
-  MOCK_NETWORK_MAPPING_SOURCES,
-  MOCK_NETWORK_MAPPING_TARGETS,
-} from '@app/queries/mocks/mappings.mock';
+import { MOCK_STORAGE_MAPPINGS, MOCK_NETWORK_MAPPINGS } from '@app/queries/mocks/mappings.mock';
 import { usePausedPollingEffect } from '@app/common/context';
 
 interface IPlanWizardProps {
@@ -86,8 +79,6 @@ const PlanWizard: React.FunctionComponent<IPlanWizardProps> = ({
             key="mapping-form-storage"
             mappingType={MappingType.Storage}
             mappingList={MOCK_STORAGE_MAPPINGS}
-            availableSources={MOCK_STORAGE_MAPPING_SOURCES}
-            availableTargets={MOCK_STORAGE_MAPPING_TARGETS}
           />
         </WizardStepContainer>
       ),
@@ -102,8 +93,6 @@ const PlanWizard: React.FunctionComponent<IPlanWizardProps> = ({
             key="mapping-form-network"
             mappingType={MappingType.Network}
             mappingList={MOCK_NETWORK_MAPPINGS}
-            availableSources={MOCK_NETWORK_MAPPING_SOURCES}
-            availableTargets={MOCK_NETWORK_MAPPING_TARGETS}
           />
         </WizardStepContainer>
       ),

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -82,7 +82,7 @@ const ProvidersPage: React.FunctionComponent = () => {
       <PageSection>
         {providersQuery.isLoading ? (
           <LoadingEmptyState />
-        ) : providersQuery.status === 'error' ? (
+        ) : providersQuery.isError ? (
           <Alert variant="danger" title="Error loading providers" />
         ) : (
           <Card>

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 import {
   PageSection,
   Title,
-  Bullseye,
   EmptyState,
-  Spinner,
   Card,
   CardBody,
   EmptyStateIcon,
@@ -29,6 +27,7 @@ import AddProviderModal from './components/AddProviderModal';
 
 import { checkAreProvidersEmpty } from './helpers';
 import { IProvidersByType } from '@app/queries/types';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 const ProvidersPage: React.FunctionComponent = () => {
   const providersQuery = useProvidersQuery();
@@ -82,14 +81,7 @@ const ProvidersPage: React.FunctionComponent = () => {
       </PageSection>
       <PageSection>
         {providersQuery.isLoading ? (
-          <Bullseye>
-            <EmptyState>
-              <div className="pf-c-empty-state__icon">
-                <Spinner size="xl" />
-              </div>
-              <Title headingLevel="h2">Loading...</Title>
-            </EmptyState>
-          </Bullseye>
+          <LoadingEmptyState />
         ) : providersQuery.status === 'error' ? (
           <Alert variant="danger" title="Error loading providers" />
         ) : (

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -106,7 +106,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
             title: (
               <List className={`provider-storage-classes-list ${spacing.mMd}`}>
                 {MOCK_STORAGE_CLASSES.map((storageClass) => (
-                  <ListItem key={storageClass}>{storageClass}</ListItem>
+                  <ListItem key={storageClass.name}>{storageClass}</ListItem>
                 ))}
               </List>
             ),

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -15,14 +15,11 @@ import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useSelectionState } from '@konveyor/lib-ui';
 import { useSortState, usePaginationState } from '@app/common/hooks';
-import OpenShiftProviderActionsDropdown from './OpenShiftProviderActionsDropdown';
+import { useStorageClassesQuery } from '@app/queries';
 import { IOpenShiftProvider } from '@app/queries/types/providers.types';
+import OpenShiftProviderActionsDropdown from './OpenShiftProviderActionsDropdown';
 import ProviderStatus from '../ProviderStatus';
 import './OpenShiftProvidersTable.css';
-import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from '@app/queries/mocks/storageClasses.mock';
-
-// TODO move these to a dependent query from providers
-const MOCK_STORAGE_CLASSES = MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
 
 interface IOpenShiftProvidersTableProps {
   providers: IOpenShiftProvider[];
@@ -31,6 +28,8 @@ interface IOpenShiftProvidersTableProps {
 const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableProps> = ({
   providers,
 }: IOpenShiftProvidersTableProps) => {
+  const storageClassesQuery = useStorageClassesQuery(providers);
+
   const columns: ICell[] = [
     { title: 'Name', transforms: [sortable] },
     { title: 'Endpoint', transforms: [sortable] },
@@ -43,14 +42,15 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
   ];
 
   const getSortValues = (provider: IOpenShiftProvider) => {
-    const { namespaceCount, vmCount, networkCount } = provider;
+    const { name, namespaceCount, vmCount, networkCount } = provider;
+    const storageClasses = storageClassesQuery.data ? storageClassesQuery.data[name] : [];
     return [
-      provider.name,
+      name,
       provider.object.spec.url,
       namespaceCount,
       vmCount,
       networkCount,
-      MOCK_STORAGE_CLASSES.length,
+      storageClasses.length,
       provider.object.status.conditions[0].type, // TODO maybe surface the most serious status condition?,
       '',
     ];
@@ -70,13 +70,14 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
 
   const rows: IRow[] = [];
   currentPageItems.forEach((provider: IOpenShiftProvider) => {
-    const { namespaceCount, vmCount, networkCount } = provider;
+    const { name, namespaceCount, vmCount, networkCount } = provider;
     const isExpanded = isProviderExpanded(provider);
+    const storageClasses = storageClassesQuery.data ? storageClassesQuery.data[name] : [];
     rows.push({
       meta: { provider },
       isOpen: isExpanded,
       cells: [
-        provider.name,
+        name,
         provider.object.spec.url,
         namespaceCount,
         vmCount,
@@ -84,7 +85,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
         {
           title: (
             <>
-              <DatabaseIcon key="storage-classes-icon" /> {MOCK_STORAGE_CLASSES.length}
+              <DatabaseIcon key="storage-classes-icon" /> {storageClasses.length}
             </>
           ),
           props: {
@@ -105,8 +106,8 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
           {
             title: (
               <List className={`provider-storage-classes-list ${spacing.mMd}`}>
-                {MOCK_STORAGE_CLASSES.map((storageClass) => (
-                  <ListItem key={storageClass.name}>{storageClass}</ListItem>
+                {storageClasses.map((storageClass) => (
+                  <ListItem key={storageClass.name}>{storageClass.name}</ListItem>
                 ))}
               </List>
             ),

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -19,9 +19,10 @@ import OpenShiftProviderActionsDropdown from './OpenShiftProviderActionsDropdown
 import { IOpenShiftProvider } from '@app/queries/types/providers.types';
 import ProviderStatus from '../ProviderStatus';
 import './OpenShiftProvidersTable.css';
+import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from '@app/queries/mocks/storageClasses.mock';
 
 // TODO move these to a dependent query from providers
-const MOCK_STORAGE_CLASSES = ['gold', 'silver', 'bronze'];
+const MOCK_STORAGE_CLASSES = MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
 
 interface IOpenShiftProvidersTableProps {
   providers: IOpenShiftProvider[];

--- a/src/app/common/components/LoadingEmptyState.tsx
+++ b/src/app/common/components/LoadingEmptyState.tsx
@@ -1,0 +1,15 @@
+import { Bullseye, EmptyState, Spinner, Title } from '@patternfly/react-core';
+import * as React from 'react';
+
+const LoadingEmptyState: React.FunctionComponent = () => (
+  <Bullseye>
+    <EmptyState variant="large">
+      <div className="pf-c-empty-state__icon">
+        <Spinner size="xl" />
+      </div>
+      <Title headingLevel="h2">Loading...</Title>
+    </EmptyState>
+  </Bullseye>
+);
+
+export default LoadingEmptyState;

--- a/src/app/common/components/LoadingEmptyState.tsx
+++ b/src/app/common/components/LoadingEmptyState.tsx
@@ -1,8 +1,14 @@
 import { Bullseye, EmptyState, Spinner, Title } from '@patternfly/react-core';
 import * as React from 'react';
 
-const LoadingEmptyState: React.FunctionComponent = () => (
-  <Bullseye>
+interface ILoadingEmptyStateProps {
+  className?: string;
+}
+
+const LoadingEmptyState: React.FunctionComponent<ILoadingEmptyStateProps> = ({
+  className = '',
+}: ILoadingEmptyStateProps) => (
+  <Bullseye className={className}>
     <EmptyState variant="large">
       <div className="pf-c-empty-state__icon">
         <Spinner size="xl" />

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -1,4 +1,4 @@
-import { UseQueryObjectConfig, QueryResult, useQuery } from 'react-query';
+import { UseQueryObjectConfig, QueryResult, useQuery, QueryStatus } from 'react-query';
 
 // TODO add useMockableMutation wrapper that just turns the mutation into a noop?
 // TODO what about usePaginatedQuery, useInfiniteQuery?
@@ -27,3 +27,24 @@ export const useMockableQuery = <TResult = unknown, TError = unknown>(
 
 export const getApiUrl = (relativePath: string): string =>
   `${process.env.REMOTE_API_URL}${relativePath}`;
+
+export const getAggregateQueryStatus = (queryResults: QueryResult<unknown>[]): QueryStatus => {
+  const isAnyLoading = queryResults.some((result) => result.isLoading);
+  const isAnyError = queryResults.some((result) => result.isError);
+  const areAllIdle = queryResults.every((result) => result.isIdle);
+  const areAllSuccess = queryResults.every((result) => result.isSuccess);
+  if (isAnyError) return QueryStatus.Error;
+  if (isAnyLoading) return QueryStatus.Loading;
+  if (areAllIdle) return QueryStatus.Idle;
+  if (areAllSuccess) return QueryStatus.Success;
+  return QueryStatus.Error; // Should never reach this, just makes TS happy
+};
+
+export const getFirstQueryError = <TError>(
+  queryResults: QueryResult<unknown, TError>[]
+): TError | null => {
+  for (const result of queryResults) {
+    if (result.isError) return result.error;
+  }
+  return null;
+};

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -44,3 +44,21 @@ export const getFirstQueryError = <TError>(
   }
   return null;
 };
+
+// Given a lookup object of keys to arrays of values,
+// Returns a copy of the object with the values sorted.
+export const sortIndexedData = <TItem, TIndexed>(
+  data: TIndexed | undefined,
+  getSortValue: (item: TItem) => string | number
+): TIndexed | undefined =>
+  data
+    ? Object.keys(data || {}).reduce(
+        (newObj, key) => ({
+          ...newObj,
+          [key]: (data || {})[key].sort((a: TItem, b: TItem) =>
+            getSortValue(a) < getSortValue(b) ? -1 : 1
+          ),
+        }),
+        {} as TIndexed
+      )
+    : undefined;

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -29,14 +29,10 @@ export const getApiUrl = (relativePath: string): string =>
   `${process.env.REMOTE_API_URL}${relativePath}`;
 
 export const getAggregateQueryStatus = (queryResults: QueryResult<unknown>[]): QueryStatus => {
-  const isAnyLoading = queryResults.some((result) => result.isLoading);
-  const isAnyError = queryResults.some((result) => result.isError);
-  const areAllIdle = queryResults.every((result) => result.isIdle);
-  const areAllSuccess = queryResults.every((result) => result.isSuccess);
-  if (isAnyError) return QueryStatus.Error;
-  if (isAnyLoading) return QueryStatus.Loading;
-  if (areAllIdle) return QueryStatus.Idle;
-  if (areAllSuccess) return QueryStatus.Success;
+  if (queryResults.some((result) => result.isError)) return QueryStatus.Error;
+  if (queryResults.some((result) => result.isLoading)) return QueryStatus.Loading;
+  if (queryResults.every((result) => result.isIdle)) return QueryStatus.Idle;
+  if (queryResults.every((result) => result.isSuccess)) return QueryStatus.Success;
   return QueryStatus.Error; // Should never reach this, just makes TS happy
 };
 

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -1,5 +1,5 @@
 export * from './providers';
 export * from './storageClasses';
+export * from './mappings';
 // export * from './plans';
-// export * from './mappings';
 // export * from './vms';

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './providers';
+export * from './storageClasses';
 // export * from './plans';
 // export * from './mappings';
 // export * from './vms';

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -33,7 +33,7 @@ export const useMappingResourceQueries = (
   // TODO vmware networks query
   // TODO openshift networks query
   // TODO vmware datastores query
-  const storageClassesQuery = useStorageClassesQuery(targetProvider);
+  const storageClassesQuery = useStorageClassesQuery(targetProvider ? [targetProvider] : null);
 
   let availableSources: MappingSource[] = [];
   let availableTargets: MappingTarget[] = [];
@@ -43,7 +43,11 @@ export const useMappingResourceQueries = (
   }
   if (mappingType === MappingType.Storage) {
     availableSources = sourceProvider ? MOCK_VMWARE_DATASTORES_BY_PROVIDER.VCenter1 : []; // TODO use query data
-    availableTargets = (targetProvider && storageClassesQuery.data) || [];
+    availableTargets =
+      (targetProvider &&
+        storageClassesQuery.data &&
+        storageClassesQuery.data[targetProvider.name]) ||
+      [];
   }
 
   const status = getAggregateQueryStatus([storageClassesQuery]); // TODO add the other queries

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -1,1 +1,60 @@
-// TODO
+import { QueryStatus } from 'react-query';
+import {
+  IVMwareProvider,
+  IOpenShiftProvider,
+  MappingType,
+  MappingSource,
+  MappingTarget,
+} from './types';
+import { useStorageClassesQuery } from './storageClasses';
+import {
+  MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER,
+  MOCK_VMWARE_NETWORKS_BY_PROVIDER,
+} from './mocks/networks.mock';
+import { MOCK_VMWARE_DATASTORES_BY_PROVIDER } from './mocks/datastores.mock';
+import { getAggregateQueryStatus, getFirstQueryError } from './helpers';
+
+// TODO actual useMappingsQuery bits
+
+interface IMappingResourcesResult {
+  availableSources: MappingSource[];
+  availableTargets: MappingTarget[];
+  isLoading: boolean;
+  isError: boolean;
+  status: QueryStatus;
+  error: unknown; // TODO not sure how to handle error types yet
+}
+
+export const useMappingResourceQueries = (
+  sourceProvider: IVMwareProvider | null,
+  targetProvider: IOpenShiftProvider | null,
+  mappingType: MappingType
+): IMappingResourcesResult => {
+  // TODO vmware networks query
+  // TODO openshift networks query
+  // TODO vmware datastores query
+  const storageClassesQuery = useStorageClassesQuery(targetProvider);
+
+  let availableSources: MappingSource[] = [];
+  let availableTargets: MappingTarget[] = [];
+  if (mappingType === MappingType.Network) {
+    availableSources = sourceProvider ? MOCK_VMWARE_NETWORKS_BY_PROVIDER.VCenter1 : []; // TODO use query data
+    availableTargets = targetProvider ? MOCK_OPENSHIFT_NETWORKS_BY_PROVIDER.OCPv_1 : []; // TODO use query data
+  }
+  if (mappingType === MappingType.Storage) {
+    availableSources = sourceProvider ? MOCK_VMWARE_DATASTORES_BY_PROVIDER.VCenter1 : []; // TODO use query data
+    availableTargets = (targetProvider && storageClassesQuery.data) || [];
+  }
+
+  const status = getAggregateQueryStatus([storageClassesQuery]); // TODO add the other queries
+  const error = getFirstQueryError([storageClassesQuery]); // TODO add the other queries
+
+  return {
+    availableSources,
+    availableTargets,
+    isLoading: status === QueryStatus.Loading,
+    isError: status === QueryStatus.Error,
+    status,
+    error,
+  };
+};

--- a/src/app/queries/mocks/helpers.ts
+++ b/src/app/queries/mocks/helpers.ts
@@ -11,14 +11,7 @@ export const updateMockStorage = (generatedMapping: Mapping): void => {
     mappings: [
       {
         name: mappingName ? mappingName : 'name1',
-        provider: {
-          source: {
-            name: provider.source.name,
-          },
-          target: {
-            name: provider.source.name,
-          },
-        },
+        provider,
         items,
       },
       ...(currentMappings?.mappings ? currentMappings.mappings : []),

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -1,21 +1,15 @@
 import { IStorageMapping, INetworkMapping, MappingType } from '../types/mappings.types';
-import { ProviderType } from '@app/common/constants';
 import { MappingSource, MappingTarget } from '../types/mappings.types';
 import { NetworkType } from '../types/providers.types';
 import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './storageClasses.mock';
+import { MOCK_PROVIDERS } from './providers.mock';
 
 const storageMapping1: IStorageMapping = {
   type: MappingType.Storage,
   name: 'vcenter1_datastore_to_OCPv_storageclass1',
   provider: {
-    source: {
-      type: ProviderType.vsphere,
-      name: 'vcenter1',
-    },
-    target: {
-      type: ProviderType.openshift,
-      name: 'ocp1',
-    },
+    source: MOCK_PROVIDERS.vsphere[0],
+    target: MOCK_PROVIDERS.openshift[0],
   },
   items: [
     {
@@ -31,14 +25,8 @@ const storageMapping2: IStorageMapping = {
   type: MappingType.Storage,
   name: 'vcenter1_datastore_to_OCPv_storageclass2',
   provider: {
-    source: {
-      type: ProviderType.vsphere,
-      name: 'vcenter1',
-    },
-    target: {
-      type: ProviderType.openshift,
-      name: 'ocp1',
-    },
+    source: MOCK_PROVIDERS.vsphere[0],
+    target: MOCK_PROVIDERS.openshift[0],
   },
   items: [
     {
@@ -65,14 +53,8 @@ const networkMapping1: INetworkMapping = {
   type: MappingType.Network,
   name: 'vcenter1_netstore_to_OCP1_network1',
   provider: {
-    source: {
-      type: ProviderType.vsphere,
-      name: 'vcenter1',
-    },
-    target: {
-      type: ProviderType.openshift,
-      name: 'ocp1',
-    },
+    source: MOCK_PROVIDERS.vsphere[0],
+    target: MOCK_PROVIDERS.openshift[0],
   },
   items: [
     {
@@ -92,14 +74,8 @@ const networkMapping2: INetworkMapping = {
   type: MappingType.Network,
   name: 'vcenter1_netstore_to_OCP1_network2',
   provider: {
-    source: {
-      type: ProviderType.vsphere,
-      name: 'vcenter1',
-    },
-    target: {
-      type: ProviderType.openshift,
-      name: 'ocp1',
-    },
+    source: MOCK_PROVIDERS.vsphere[0],
+    target: MOCK_PROVIDERS.openshift[0],
   },
   items: [
     {

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -2,6 +2,7 @@ import { IStorageMapping, INetworkMapping, MappingType } from '../types/mappings
 import { ProviderType } from '@app/common/constants';
 import { MappingSource, MappingTarget } from '../types/mappings.types';
 import { NetworkType } from '../types/providers.types';
+import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './storageClasses.mock';
 
 const storageMapping1: IStorageMapping = {
   type: MappingType.Storage,
@@ -51,12 +52,14 @@ const storageMapping2: IStorageMapping = {
 
 export const MOCK_STORAGE_MAPPINGS: IStorageMapping[] = [storageMapping1, storageMapping2];
 
+// TODO the mocks we use for this should be actual network/storage object mocks
 export const MOCK_STORAGE_MAPPING_SOURCES: MappingSource[] = [
   { id: '1', name: 'vmware-datastore-1' },
   { id: '2', name: 'vmware-datastore-2' },
 ];
 
-export const MOCK_STORAGE_MAPPING_TARGETS: MappingTarget[] = ['gold', 'silver', 'bronze'];
+export const MOCK_STORAGE_MAPPING_TARGETS: MappingTarget[] =
+  MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
 
 const networkMapping1: INetworkMapping = {
   type: MappingType.Network,

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -16,7 +16,7 @@ const storageMapping1: IStorageMapping = {
       source: {
         id: 'id1',
       },
-      target: 'storageclass1',
+      target: MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1[0],
     },
   ],
 };
@@ -33,7 +33,7 @@ const storageMapping2: IStorageMapping = {
       source: {
         id: 'id2',
       },
-      target: 'storageclass2',
+      target: MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1[1],
     },
   ],
 };

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -40,15 +40,6 @@ const storageMapping2: IStorageMapping = {
 
 export const MOCK_STORAGE_MAPPINGS: IStorageMapping[] = [storageMapping1, storageMapping2];
 
-// TODO the mocks we use for this should be actual network/storage object mocks
-export const MOCK_STORAGE_MAPPING_SOURCES: MappingSource[] = [
-  { id: '1', name: 'vmware-datastore-1' },
-  { id: '2', name: 'vmware-datastore-2' },
-];
-
-export const MOCK_STORAGE_MAPPING_TARGETS: MappingTarget[] =
-  MOCK_STORAGE_CLASSES_BY_PROVIDER.OCPv_1;
-
 const networkMapping1: INetworkMapping = {
   type: MappingType.Network,
   name: 'vcenter1_netstore_to_OCP1_network1',
@@ -92,21 +83,3 @@ const networkMapping2: INetworkMapping = {
 };
 
 export const MOCK_NETWORK_MAPPINGS: INetworkMapping[] = [networkMapping1, networkMapping2];
-
-export const MOCK_NETWORK_MAPPING_SOURCES: MappingSource[] = [
-  { id: '1', name: 'vcenter1-netstore-1' },
-  { id: '2', name: 'vcenter1-netstore-2' },
-];
-
-export const MOCK_NETWORK_MAPPING_TARGETS: MappingTarget[] = [
-  {
-    type: NetworkType.Pod,
-    name: 'network1',
-    namespace: 'namespace-test',
-  },
-  {
-    type: NetworkType.Pod,
-    name: 'network2',
-    namespace: 'namespace-test',
-  },
-];

--- a/src/app/queries/mocks/storageClasses.mock.ts
+++ b/src/app/queries/mocks/storageClasses.mock.ts
@@ -1,0 +1,36 @@
+import { IStorageClass } from '../types';
+import { MOCK_PROVIDERS } from './providers.mock';
+
+export let MOCK_STORAGE_CLASSES_BY_PROVIDER: { [key: string]: IStorageClass[] } = {};
+
+if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+  const exampleStorageClasses: IStorageClass[] = [
+    {
+      uid: 'foo-sc-uid-1',
+      version: '1',
+      namespace: 'foo',
+      name: 'standard',
+      selfLink: '/foo',
+    },
+    {
+      uid: 'foo-sc-uid-2',
+      version: '1',
+      namespace: 'foo',
+      name: 'large',
+      selfLink: '/foo',
+    },
+    {
+      uid: 'foo-sc-uid-3',
+      version: '1',
+      namespace: 'foo',
+      name: 'small',
+      selfLink: '/foo',
+    },
+  ];
+
+  MOCK_STORAGE_CLASSES_BY_PROVIDER = {
+    OCPv_1: [...exampleStorageClasses],
+    OCPv_2: [...exampleStorageClasses],
+    OCPv_3: [...exampleStorageClasses],
+  };
+}

--- a/src/app/queries/mocks/storageClasses.mock.ts
+++ b/src/app/queries/mocks/storageClasses.mock.ts
@@ -1,5 +1,4 @@
 import { IStorageClass } from '../types';
-import { MOCK_PROVIDERS } from './providers.mock';
 
 export let MOCK_STORAGE_CLASSES_BY_PROVIDER: { [key: string]: IStorageClass[] } = {};
 

--- a/src/app/queries/mocks/storageClasses.mock.ts
+++ b/src/app/queries/mocks/storageClasses.mock.ts
@@ -2,34 +2,37 @@ import { IStorageClass } from '../types';
 
 export let MOCK_STORAGE_CLASSES_BY_PROVIDER: { [key: string]: IStorageClass[] } = {};
 
-if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const exampleStorageClasses: IStorageClass[] = [
-    {
-      uid: 'foo-sc-uid-1',
-      version: '1',
-      namespace: 'foo',
-      name: 'standard',
-      selfLink: '/foo',
-    },
-    {
-      uid: 'foo-sc-uid-2',
-      version: '1',
-      namespace: 'foo',
-      name: 'large',
-      selfLink: '/foo',
-    },
-    {
-      uid: 'foo-sc-uid-3',
-      version: '1',
-      namespace: 'foo',
-      name: 'small',
-      selfLink: '/foo',
-    },
-  ];
+// TODO un-comment this condition when we don't have other mocked components depending on this data even in remote mode
+//if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
-  MOCK_STORAGE_CLASSES_BY_PROVIDER = {
-    OCPv_1: [...exampleStorageClasses],
-    OCPv_2: [...exampleStorageClasses],
-    OCPv_3: [...exampleStorageClasses],
-  };
-}
+const exampleStorageClasses: IStorageClass[] = [
+  {
+    uid: 'foo-sc-uid-1',
+    version: '1',
+    namespace: 'foo',
+    name: 'standard',
+    selfLink: '/foo',
+  },
+  {
+    uid: 'foo-sc-uid-2',
+    version: '1',
+    namespace: 'foo',
+    name: 'large',
+    selfLink: '/foo',
+  },
+  {
+    uid: 'foo-sc-uid-3',
+    version: '1',
+    namespace: 'foo',
+    name: 'small',
+    selfLink: '/foo',
+  },
+];
+
+MOCK_STORAGE_CLASSES_BY_PROVIDER = {
+  OCPv_1: [...exampleStorageClasses],
+  OCPv_2: [...exampleStorageClasses],
+  OCPv_3: [...exampleStorageClasses],
+};
+
+//}

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -1,7 +1,7 @@
 import { QueryResult } from 'react-query';
 import { usePollingContext } from '@app/common/context';
 import { POLLING_INTERVAL } from './constants';
-import { useMockableQuery, getApiUrl } from './helpers';
+import { useMockableQuery, getApiUrl, sortIndexedData } from './helpers';
 import { MOCK_PROVIDERS } from './mocks/providers.mock';
 import { IProvidersByType, Provider } from './types';
 
@@ -20,16 +20,6 @@ export const useProvidersQuery = (): QueryResult<IProvidersByType> => {
   );
   return {
     ...result,
-    data: result.data
-      ? (Object.keys(result.data || {}).reduce(
-          (newObj, key) => ({
-            ...newObj,
-            [key]: (result.data || {})[key].sort((a: Provider, b: Provider) =>
-              a.name < b.name ? -1 : 1
-            ),
-          }),
-          {} as IProvidersByType
-        ) as IProvidersByType)
-      : undefined,
+    data: sortIndexedData<Provider, IProvidersByType>(result.data, (provider) => provider.name),
   };
 };

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -20,14 +20,16 @@ export const useProvidersQuery = (): QueryResult<IProvidersByType> => {
   );
   return {
     ...result,
-    data: Object.keys(result.data || {}).reduce(
-      (newObj, key) => ({
-        ...newObj,
-        [key]: (result.data || {})[key].sort((a: Provider, b: Provider) =>
-          a.name < b.name ? -1 : 1
-        ),
-      }),
-      {} as IProvidersByType
-    ) as IProvidersByType,
+    data: result.data
+      ? (Object.keys(result.data || {}).reduce(
+          (newObj, key) => ({
+            ...newObj,
+            [key]: (result.data || {})[key].sort((a: Provider, b: Provider) =>
+              a.name < b.name ? -1 : 1
+            ),
+          }),
+          {} as IProvidersByType
+        ) as IProvidersByType)
+      : undefined,
   };
 };

--- a/src/app/queries/storageClasses.ts
+++ b/src/app/queries/storageClasses.ts
@@ -1,7 +1,7 @@
 import { QueryResult } from 'react-query';
 import { usePollingContext } from '@app/common/context';
 import { POLLING_INTERVAL } from './constants';
-import { useMockableQuery, getApiUrl } from './helpers';
+import { useMockableQuery, getApiUrl, sortIndexedData } from './helpers';
 import { IOpenShiftProvider, IStorageClass, IStorageClassesByProvider } from './types';
 import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './mocks/storageClasses.mock';
 
@@ -49,17 +49,6 @@ export const useStorageClassesQuery = (
   );
   return {
     ...result,
-    // TODO maybe factor this out into a sortIndexedResources helper or something
-    data: result.data
-      ? (Object.keys(result.data || {}).reduce(
-          (newObj, key) => ({
-            ...newObj,
-            [key]: (result.data || {})[key].sort((a: IStorageClass, b: IStorageClass) =>
-              a.name < b.name ? -1 : 1
-            ),
-          }),
-          {} as IStorageClassesByProvider
-        ) as IStorageClassesByProvider)
-      : undefined,
+    data: sortIndexedData<IStorageClass, IStorageClassesByProvider>(result.data, (sc) => sc.name),
   };
 };

--- a/src/app/queries/storageClasses.ts
+++ b/src/app/queries/storageClasses.ts
@@ -1,0 +1,33 @@
+import { QueryResult } from 'react-query';
+import { usePollingContext } from '@app/common/context';
+import { POLLING_INTERVAL } from './constants';
+import { useMockableQuery, getApiUrl } from './helpers';
+import { IOpenShiftProvider, IStorageClass } from './types';
+import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './mocks/storageClasses.mock';
+
+export const STORAGE_CLASSES_QUERY_KEY = 'storageClasses';
+
+// TODO handle error messages? (query.status will correctly show 'error', but error messages aren't collected)
+export const useStorageClassesQuery = (
+  provider: IOpenShiftProvider | null
+): QueryResult<IStorageClass[]> => {
+  const { isPollingEnabled } = usePollingContext();
+  const result = useMockableQuery<IStorageClass[]>(
+    {
+      queryKey: `${STORAGE_CLASSES_QUERY_KEY}-${provider?.name || ''}`,
+      queryFn: () =>
+        fetch(getApiUrl(`${provider?.selfLink || ''}/storageclasses`)).then((res) => res.json()),
+      config: {
+        enabled: !!provider, // Don't fetch until a provider is selected / defined
+        refetchInterval: isPollingEnabled ? POLLING_INTERVAL : false,
+      },
+    },
+    MOCK_STORAGE_CLASSES_BY_PROVIDER[provider?.name || '']
+  );
+  return {
+    ...result,
+    data: result.data
+      ? result.data.sort((a: IStorageClass, b: IStorageClass) => (a.name < b.name ? -1 : 1))
+      : undefined,
+  };
+};

--- a/src/app/queries/types/index.ts
+++ b/src/app/queries/types/index.ts
@@ -3,3 +3,4 @@ export * from './hooks.types';
 export * from './mappings.types';
 export * from './plans.types';
 export * from './providers.types';
+export * from './storageClasses.types';

--- a/src/app/queries/types/mappings.types.ts
+++ b/src/app/queries/types/mappings.types.ts
@@ -18,16 +18,16 @@ export enum MappingType {
 
 export interface INetworkMappingItem {
   source: {
-    id: string;
+    id: string; // TODO see what these actually need to be in the API?
   };
   target: IOpenShiftNetwork;
 }
 
 export interface IStorageMappingItem {
   source: {
-    id: string;
+    id: string; // TODO see what these actually need to be in the API?
   };
-  target: string; // storage class
+  target: IStorageClass;
 }
 
 export type MappingItem = INetworkMappingItem | IStorageMappingItem;

--- a/src/app/queries/types/mappings.types.ts
+++ b/src/app/queries/types/mappings.types.ts
@@ -2,7 +2,8 @@
 // These types should probably be restructured to match API data later.
 
 import { ProviderType } from '@app/common/constants';
-import { IOpenShiftNetwork, IVMwareDatastore, IVMwareNetwork } from '../types/providers.types';
+import { IOpenShiftNetwork, IVMwareDatastore, IVMwareNetwork } from './providers.types';
+import { IStorageClass } from './storageClasses.types';
 
 export enum MappingType {
   Network = 'Network',
@@ -55,4 +56,4 @@ export interface IStorageMapping extends ICommonMapping {
 export type Mapping = INetworkMapping | IStorageMapping;
 
 export type MappingSource = IVMwareDatastore | IVMwareNetwork;
-export type MappingTarget = IOpenShiftNetwork | string; // string = storage class
+export type MappingTarget = IOpenShiftNetwork | IStorageClass;

--- a/src/app/queries/types/mappings.types.ts
+++ b/src/app/queries/types/mappings.types.ts
@@ -2,7 +2,13 @@
 // These types should probably be restructured to match API data later.
 
 import { ProviderType } from '@app/common/constants';
-import { IOpenShiftNetwork, IVMwareDatastore, IVMwareNetwork } from './providers.types';
+import {
+  IOpenShiftNetwork,
+  IOpenShiftProvider,
+  IVMwareDatastore,
+  IVMwareNetwork,
+  IVMwareProvider,
+} from './providers.types';
 import { IStorageClass } from './storageClasses.types';
 
 export enum MappingType {
@@ -30,15 +36,8 @@ export interface ICommonMapping {
   type: MappingType;
   name: string;
   provider: {
-    // TODO Should this instead use unique provider ids? what if we rename providers?
-    source: {
-      type: ProviderType;
-      name: string;
-    };
-    target: {
-      type: ProviderType;
-      name: string;
-    };
+    source: IVMwareProvider;
+    target: IOpenShiftProvider;
   };
   items: MappingItem[];
 }

--- a/src/app/queries/types/storageClasses.types.ts
+++ b/src/app/queries/types/storageClasses.types.ts
@@ -5,3 +5,7 @@ export interface IStorageClass {
   name: string;
   selfLink: string;
 }
+
+export interface IStorageClassesByProvider {
+  [providerName: string]: IStorageClass[];
+}

--- a/src/app/queries/types/storageClasses.types.ts
+++ b/src/app/queries/types/storageClasses.types.ts
@@ -1,0 +1,7 @@
+export interface IStorageClass {
+  uid: string;
+  version: string;
+  namespace: string;
+  name: string;
+  selfLink: string;
+}


### PR DESCRIPTION
Closes #67 

`useStorageClassesQuery` takes a nullable array of providers, and if it is null the query is disabled. Once the providers become defined, the query fetches storage classes for each provider (concurrently runs a fetch for each one, bundled up into one promise with `Promise.all`), and reduces them into a lookup object indexed by provider name. It's a bit weird since in some places we call it with only one provider and in some we call it with multiple, and those two result caches can't be shared because of the different keys. I don't think it's worth optimizing away though, and this pattern guarantees correctness when providers change.

`useMappingResourceQueries` is intended as a wrapper around all queries needed for the `availableSources` (networks, datastores) and `availableTargets` (networks, storage classes) used in various mapping-related views. Currently the only real query it uses is `useStorageClassesQuery`, and it uses the existing mock data for the rest of its return values.

As part of making `useMappingResourceQueries` I realized it would be useful to be able to mount multiple query hooks and get an aggregate status for all of them, so I abstracted out that behavior into the helper functions `getAggregateQueryStatus` and `getFirstQueryError`. Those can be used to get an overall view of whether any of the queries in the list are loading or errored, or whether all of them are idle or successful. If we need to use a bunch of queries together and show one loading state, we can use these.

I refactored the storage class types from plain strings to objects with `name` properties, which had some ripple effects and made some of our logic unnecessary, so I cut some of that out.

Then, I used these new queries to properly provide storage classes to the AddEditMappingModal, MappingDetailView (mappings table) and OpenShiftProvidersTable ✨ 