### PR TITLE
Fix remote-mode error caused by premature disabling of storageClasses mock

### DIFF
--- a/src/app/queries/mocks/storageClasses.mock.ts
+++ b/src/app/queries/mocks/storageClasses.mock.ts
@@ -2,34 +2,35 @@ import { IStorageClass } from '../types';
 
 export let MOCK_STORAGE_CLASSES_BY_PROVIDER: { [key: string]: IStorageClass[] } = {};
 
-if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const exampleStorageClasses: IStorageClass[] = [
-    {
-      uid: 'foo-sc-uid-1',
-      version: '1',
-      namespace: 'foo',
-      name: 'standard',
-      selfLink: '/foo',
-    },
-    {
-      uid: 'foo-sc-uid-2',
-      version: '1',
-      namespace: 'foo',
-      name: 'large',
-      selfLink: '/foo',
-    },
-    {
-      uid: 'foo-sc-uid-3',
-      version: '1',
-      namespace: 'foo',
-      name: 'small',
-      selfLink: '/foo',
-    },
-  ];
+// TODO put this condition back when we don't directly import mocks into components anymore
+// if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+const exampleStorageClasses: IStorageClass[] = [
+  {
+    uid: 'foo-sc-uid-1',
+    version: '1',
+    namespace: 'foo',
+    name: 'standard',
+    selfLink: '/foo',
+  },
+  {
+    uid: 'foo-sc-uid-2',
+    version: '1',
+    namespace: 'foo',
+    name: 'large',
+    selfLink: '/foo',
+  },
+  {
+    uid: 'foo-sc-uid-3',
+    version: '1',
+    namespace: 'foo',
+    name: 'small',
+    selfLink: '/foo',
+  },
+];
 
-  MOCK_STORAGE_CLASSES_BY_PROVIDER = {
-    OCPv_1: [...exampleStorageClasses],
-    OCPv_2: [...exampleStorageClasses],
-    OCPv_3: [...exampleStorageClasses],
-  };
-}
+MOCK_STORAGE_CLASSES_BY_PROVIDER = {
+  OCPv_1: [...exampleStorageClasses],
+  OCPv_2: [...exampleStorageClasses],
+  OCPv_3: [...exampleStorageClasses],
+};
+//}


### PR DESCRIPTION
Prevents the app from crashing in `start:dev:remote` mode. Good catch @ibolton336 