### PR TITLE
Fix handling of CORS errors in authorizedFetch

### DIFF
--- a/src/app/common/CertErrorPage.tsx
+++ b/src/app/common/CertErrorPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Card, CardBody, Alert } from '@patternfly/react-core';
+import { Alert, PageSection } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useHistory } from 'react-router-dom';
 import { useNetworkContext } from './context/NetworkContext';
 
@@ -10,26 +11,28 @@ const CertErrorPage: React.FunctionComponent = () => {
     history.push('/');
   }
   return (
-    <>
+    <PageSection variant="light">
       {selfSignedCertUrl ? (
-        <Card>
-          <CardBody>
-            <Alert title="Certificate error">
-              A certificate error has occurred, likely due to the usage of self signed certificates
-              in one of the clusters. Please try to visit the failed url and accept the CA:
-              <a href={selfSignedCertUrl}> {selfSignedCertUrl}</a>
-              <div />
-              The correct way to address this is to install your self CA into your browser.
-              <div />
-              NOTE: The contents of the resulting page may report &quot;unauthorized&quot; This is
-              expected. After accepting the certificate, please reload the app.
-            </Alert>
-          </CardBody>
-        </Card>
+        <Alert title="Certificate error" className={spacing.mMd}>
+          A certificate error has occurred, likely due to the usage of self signed certificates in
+          one of the clusters.
+          <br />
+          <br />
+          Please try to visit the failed url and accept the CA:
+          <br />
+          <a href={selfSignedCertUrl}> {selfSignedCertUrl}</a>
+          <br />
+          <br />
+          The correct way to address this is to install your self CA into your browser.
+          <br />
+          <br />
+          NOTE: The contents of the resulting page may report &quot;unauthorized&quot; This is
+          expected. After accepting the certificate, please reload the app.
+        </Alert>
       ) : (
         <div />
       )}
-    </>
+    </PageSection>
   );
 };
 

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -4,18 +4,6 @@ import { QueryFunction } from 'react-query/types/core/types';
 import { useHistory } from 'react-router-dom';
 import { History, LocationState } from 'history';
 
-interface HttpResponse<T> extends Response {
-  parsedBody?: T;
-}
-
-export const isSelfSignedCertError = <T>(response: HttpResponse<T>): boolean => {
-  // HACK: Doing our best to determine whether or not the
-  // error was produced due to a self signed cert error.
-  // It's an extremely barren object.
-  const certErrorText = 'Failed to fetch';
-  return response instanceof TypeError && response.message === certErrorText;
-};
-
 interface IFetchContext {
   history: History<LocationState>;
   setSelfSignedCertUrl: INetworkContext['setSelfSignedCertUrl'];
@@ -28,25 +16,27 @@ export const useFetchContext = (): IFetchContext => ({
 
 export const authorizedFetch = async <T>(url: string, fetchContext: IFetchContext): Promise<T> => {
   const { history, setSelfSignedCertUrl } = fetchContext;
-
-  const handleFetchResponse = (response: HttpResponse<T>) => {
-    if (isSelfSignedCertError(response)) {
-      setSelfSignedCertUrl(url);
-      history.push(`/cert-error`);
-    }
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${VIRT_META.oauth.clientSecret}`,
+      },
+    });
     if (response.ok && response.json) {
       return response.json();
     } else {
-      return response; // or maybe something that pulls out the error message? we can figure that out later
+      return Promise.reject(response);
     }
-  };
-
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${VIRT_META.oauth.clientSecret}`,
-    },
-  });
-  return handleFetchResponse(response);
+  } catch (error) {
+    // HACK: Doing our best to determine whether or not the
+    // error was produced due to a self signed cert error.
+    // It's an extremely barren object.
+    if (error instanceof TypeError) {
+      setSelfSignedCertUrl(url);
+      history.push('/cert-error');
+    }
+    return Promise.reject(error);
+  }
 };
 
 export const useAuthorizedFetch = <T>(url: string): QueryFunction<T> => {


### PR DESCRIPTION
In my commits for #94 I broke the redirect for CORS errors, this fixes it and tweaks the look and feel of that page a bit.