### PR TITLE
Use virtMeta.json with a capital M everywhere

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -11,7 +11,7 @@ let virtMetaStr;
 if (process.env['DATA_SOURCE'] === 'mock') {
   virtMetaStr = '{ "oauth": {} }';
 } else {
-  const virtMetaFile = process.env['VIRTMETA_FILE'] || '/srv/virtmeta.json';
+  const virtMetaFile = process.env['VIRTMETA_FILE'] || '/srv/virtMeta.json';
   virtMetaStr = fs.readFileSync(virtMetaFile, 'utf8');
 }
 


### PR DESCRIPTION
This was inconsistent in the fallback default used by `server.js` and the Dockerfile value. It also should be changed to `virtMeta.json` with a capital M in the controller.