### PR TITLE
Add target namespace selection to General step of plan wizard

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Alert, Form, FormGroup, TextArea, Title } from '@patternfly/react-core';
-import { ValidatedTextInput } from '@konveyor/lib-ui';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { IOpenShiftProvider, IVMwareProvider } from '@app/queries/types';
@@ -35,7 +36,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGene
   })) as OptionWithValue<IOpenShiftProvider>[];
 
   return (
-    <Form>
+    <Form className={spacing.pbXl}>
       <Title headingLevel="h2" size="md">
         Give your plan a name and a description
       </Title>
@@ -62,8 +63,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGene
         label="Source provider"
         isRequired
         fieldId="source-provider"
-        helperTextInvalid={form.fields.sourceProvider.error}
-        validated={form.fields.sourceProvider.isValid ? 'default' : 'error'}
+        {...getFormGroupProps(form.fields.sourceProvider)}
       >
         <SimpleSelect
           id="source-provider"
@@ -87,8 +87,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGene
         label="Target provider"
         isRequired
         fieldId="target-provider"
-        helperTextInvalid={form.fields.targetProvider.error}
-        validated={form.fields.targetProvider.isValid ? 'default' : 'error'}
+        {...getFormGroupProps(form.fields.targetProvider)}
       >
         <SimpleSelect
           id="target-provider"
@@ -105,6 +104,25 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGene
             )
           }
           placeholderText="Select a provider"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="Target namespace"
+        isRequired
+        fieldId="target-namespace"
+        {...getFormGroupProps(form.fields.targetNamespace)}
+      >
+        <SimpleSelect
+          variant="typeahead"
+          isCreatable
+          id="target-namespace"
+          aria-label="Target namespace"
+          options={['mock-namespace-1', 'mock-namespace-2']}
+          value={form.values.targetNamespace}
+          onChange={(selection) => form.fields.targetNamespace.setValue(selection as string)}
+          placeholderText="Select a namespace"
+          isDisabled={!form.values.targetProvider}
         />
       </FormGroup>
     </Form>

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -63,6 +63,7 @@ const usePlanWizardFormState = () => ({
       null,
       yup.mixed<IOpenShiftProvider>().label('Target provider').required()
     ),
+    targetNamespace: useFormField('', yup.string().label('Target namespace').required()),
   }),
   filterVMs: useFormState({
     treeType: useFormField<VMwareTreeType>(VMwareTreeType.Host, yup.mixed<VMwareTreeType>()),

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -33,6 +33,8 @@ const Review: React.FunctionComponent<IReviewProps> = ({
           <GridItem md={9}>{forms.general.values.planDescription}</GridItem>
         </>
       ) : null}
+      <GridItem md={3}>Target namespace</GridItem>
+      <GridItem md={9}>{forms.general.values.targetNamespace}</GridItem>
       <GridItem md={3}>Network mapping</GridItem>
       <GridItem md={9}>
         <MappingDetailView mappingType={MappingType.Network} mapping={networkMapping} />

--- a/src/app/queries/mocks/namespaces.mock.ts
+++ b/src/app/queries/mocks/namespaces.mock.ts
@@ -1,0 +1,13 @@
+import { IOpenShiftNamespace } from '../types/namespaces.types';
+
+export let MOCK_OPENSHIFT_NAMESPACES: IOpenShiftNamespace[] = [];
+
+if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+  MOCK_OPENSHIFT_NAMESPACES = [
+    { selfLink: '/foo/namespace/1', name: 'openshift-migration' },
+    { selfLink: '/foo/namespace/2', name: 'example-project' },
+    { selfLink: '/foo/namespace/3', name: 'test-namespace' },
+    { selfLink: '/foo/namespace/4', name: 'x-namespace-4' },
+    { selfLink: '/foo/namespace/5', name: 'x-namespace-5' },
+  ];
+}

--- a/src/app/queries/namespaces.ts
+++ b/src/app/queries/namespaces.ts
@@ -1,0 +1,25 @@
+import { usePollingContext } from '@app/common/context';
+import { QueryResult } from 'react-query';
+import { POLLING_INTERVAL } from './constants';
+import { getInventoryApiUrl, sortResultsByName, useMockableQuery } from './helpers';
+import { IOpenShiftProvider } from './types';
+import { useAuthorizedFetch } from './fetchHelpers';
+import { IOpenShiftNamespace } from './types/namespaces.types';
+import { MOCK_OPENSHIFT_NAMESPACES } from './mocks/namespaces.mock';
+
+export const useNamespacesQuery = (
+  provider: IOpenShiftProvider | null
+): QueryResult<IOpenShiftNamespace[]> => {
+  const result = useMockableQuery<IOpenShiftNamespace[]>(
+    {
+      queryKey: `namespaces:${provider?.name}`,
+      queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/namespaces`)),
+      config: {
+        enabled: !!provider,
+        refetchInterval: usePollingContext().isPollingEnabled ? POLLING_INTERVAL : false,
+      },
+    },
+    MOCK_OPENSHIFT_NAMESPACES
+  );
+  return sortResultsByName(result);
+};

--- a/src/app/queries/types/namespaces.types.ts
+++ b/src/app/queries/types/namespaces.types.ts
@@ -1,0 +1,4 @@
+export interface IOpenShiftNamespace {
+  selfLink: string;
+  name: string;
+}


### PR DESCRIPTION
Resolves #134 

The `/namespaces` API endpoint under a provider used by the query doesn't exist yet, so we shouldn't merge this until we can test against @jortel's updated cluster once that is added.

Ready for review, but marking as draft to prevent merging for now.