### PR TITLE
Adds filter to VMMigrationDetails

### DIFF
--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -82,9 +82,9 @@ const VMMigrationDetails: React.FunctionComponent = () => {
     },
     {
       key: 'end',
-      title: 'Finished time',
+      title: 'End time',
       type: FilterType.search,
-      placeholderText: 'Filter by finished time ...',
+      placeholderText: 'Filter by ended time ...',
       getItemValue: (item) => {
         return item.schedule.end ? item.schedule.end : '';
       },


### PR DESCRIPTION
Resolves https://github.com/konveyor/virt-ui/issues/141

Allows to filter VM name, start and end times.
Status could be added if needed, meanwhile we better have useMockableQuery in place first to be aligned with final data.