### PR TITLE
Handle token expiry 

### DIFF
--- a/src/app/common/context/NetworkContext.tsx
+++ b/src/app/common/context/NetworkContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { LocalStorageKey, useLocalStorageContext } from './LocalStorageContext';
+import { setTokenExpiryHandler } from '@konveyor/lib-ui/dist';
 
 export interface INetworkContext {
   setSelfSignedCertUrl: (url: string) => void;
@@ -33,6 +34,11 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
     setCurrentUser(JSON.stringify(user));
     history.push('/');
   };
+
+  setTokenExpiryHandler(() => {
+    console.error('token expired');
+    setCurrentUser('');
+  });
 
   return (
     <NetworkContext.Provider

--- a/src/app/common/context/NetworkContext.tsx
+++ b/src/app/common/context/NetworkContext.tsx
@@ -7,6 +7,7 @@ export interface INetworkContext {
   selfSignedCertUrl: string;
   saveLoginToken: (user: string, history: any) => void;
   currentUser: string;
+  checkExpiry: (user: string, history: any) => void;
 }
 
 const NetworkContext = React.createContext<INetworkContext>({
@@ -18,6 +19,9 @@ const NetworkContext = React.createContext<INetworkContext>({
     console.error('saveLoginToken was called without a NetworkContextProvider in the tree');
   },
   currentUser: '',
+  checkExpiry: () => {
+    console.error('checkExpiry was called without a NetworkContextProvider in the tree');
+  },
 });
 
 interface INetworkContextProviderProps {
@@ -35,10 +39,12 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
     history.push('/');
   };
 
-  setTokenExpiryHandler(() => {
-    console.error('token expired');
-    setCurrentUser('');
-  });
+  const checkExpiry = (error, history) => {
+    if (error.response && error.response.status === 401) {
+      setCurrentUser('');
+      history.push('/');
+    }
+  };
 
   return (
     <NetworkContext.Provider
@@ -47,6 +53,7 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
         setSelfSignedCertUrl,
         saveLoginToken,
         currentUser: currentUser || '',
+        checkExpiry,
       }}
     >
       {children}

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -7,11 +7,13 @@ import { History, LocationState } from 'history';
 interface IFetchContext {
   history: History<LocationState>;
   setSelfSignedCertUrl: INetworkContext['setSelfSignedCertUrl'];
+  checkExpiry: INetworkContext['checkExpiry'];
 }
 
 export const useFetchContext = (): IFetchContext => ({
   history: useHistory(),
   setSelfSignedCertUrl: useNetworkContext().setSelfSignedCertUrl,
+  checkExpiry: useNetworkContext().checkExpiry,
 });
 
 export const authorizedFetch = async <T>(
@@ -19,7 +21,7 @@ export const authorizedFetch = async <T>(
   fetchContext: IFetchContext,
   extraHeaders: RequestInit['headers'] = {}
 ): Promise<T> => {
-  const { history, setSelfSignedCertUrl } = fetchContext;
+  const { history, setSelfSignedCertUrl, checkExpiry } = fetchContext;
   try {
     const response = await fetch(url, {
       headers: {
@@ -42,6 +44,7 @@ export const authorizedFetch = async <T>(
       setSelfSignedCertUrl(url);
       history.push('/cert-error');
     }
+    checkExpiry(error, history);
     return Promise.reject(error);
   }
 };


### PR DESCRIPTION
Closes #137 
Pulls in the setTokenExpiryHandler function from the k8s client library & defines it in the network context. Anytime we make an api call which fails with a 401 code using the k8s client, this function will be called internally by the k8s client. This will refresh the expired token by clearing out the currentUser from local storage, forcing a new oauth token to be requested and validated. 