### PR TITLE
Initial plan to display accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.8.2",
+    "@konveyor/lib-ui": "^1.9.0",
     "@patternfly/react-core": "^4.60.1",
     "@patternfly/react-icons": "^4.7.6",
     "@patternfly/react-styles": "^4.7.5",

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -160,17 +160,19 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     if (hasCondition(conditions, PlanStatusAPIType.Ready) && !plan.status?.migration?.started) {
       buttonType = ActionButtonType.Start;
       isStatusReady = true;
+    } else if (hasCondition(conditions, PlanStatusAPIType.Executing)) {
+      buttonType = ActionButtonType.Cancel;
+      title = PlanStatusDisplayType.Executing;
     } else if (hasCondition(conditions, PlanStatusAPIType.Succeeded)) {
       title = PlanStatusDisplayType.Succeeded;
       variant = ProgressVariant.success;
     } else if (hasCondition(conditions, PlanStatusAPIType.Failed)) {
       title = PlanStatusDisplayType.Failed;
       variant = ProgressVariant.danger;
-    } else if (hasCondition(conditions, PlanStatusAPIType.Executing)) {
-      buttonType = ActionButtonType.Cancel;
-      title = PlanStatusDisplayType.Executing;
-    } else {
+    } else if (!plan.status) {
       isInitializing = true;
+    } else {
+      console.log('Migration plan Status Error:', plan);
     }
 
     const { statusValue = 0, statusMessage = '' } = ratioVMs(plan);

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -198,7 +198,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         plan.spec.vms.length,
         {
           title: isInitializing ? (
-            <StatusIcon status={StatusType.Warning} label={PlanStatusDisplayType.Initializing} />
+            <Spinner size="md" />
           ) : isStatusReady ? (
             <StatusIcon status={StatusType.Ok} label={PlanStatusDisplayType.Ready} />
           ) : (

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -150,6 +150,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
   currentPageItems.forEach((plan: IPlan) => {
     let buttonType: ActionButtonType | null = null;
+    let isInitializing = false;
     let isStatusReady = false;
     let title = '';
     let variant: ProgressVariant | undefined;
@@ -165,9 +166,11 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     } else if (hasCondition(conditions, PlanStatusAPIType.Failed)) {
       title = PlanStatusDisplayType.Failed;
       variant = ProgressVariant.danger;
-    } else {
+    } else if (hasCondition(conditions, PlanStatusAPIType.Executing)) {
       buttonType = ActionButtonType.Cancel;
       title = PlanStatusDisplayType.Executing;
+    } else {
+      isInitializing = true;
     }
 
     const { statusValue = 0, statusMessage = '' } = ratioVMs(plan);
@@ -194,7 +197,9 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         targetProvider?.name || '',
         plan.spec.vms.length,
         {
-          title: isStatusReady ? (
+          title: isInitializing ? (
+            <StatusIcon status={StatusType.Warning} label={PlanStatusDisplayType.Initializing} />
+          ) : isStatusReady ? (
             <StatusIcon status={StatusType.Ok} label={PlanStatusDisplayType.Ready} />
           ) : (
             <Progress

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -200,7 +200,17 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         plan.spec.vms.length,
         {
           title: isInitializing ? (
-            <Spinner size="md" />
+            <Flex
+              spaceItems={{ default: 'spaceItemsSm' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+              flexWrap={{ default: 'nowrap' }}
+              style={{ whiteSpace: 'nowrap' }}
+            >
+              <FlexItem>
+                <Spinner size="md" />
+              </FlexItem>
+              <FlexItem>Initializing</FlexItem>
+            </Flex>
           ) : isStatusReady ? (
             <StatusIcon status={StatusType.Ok} label={PlanStatusDisplayType.Ready} />
           ) : (

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -200,17 +200,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         plan.spec.vms.length,
         {
           title: isInitializing ? (
-            <Flex
-              spaceItems={{ default: 'spaceItemsSm' }}
-              alignItems={{ default: 'alignItemsCenter' }}
-              flexWrap={{ default: 'nowrap' }}
-              style={{ whiteSpace: 'nowrap' }}
-            >
-              <FlexItem>
-                <Spinner size="md" />
-              </FlexItem>
-              <FlexItem>Initializing</FlexItem>
-            </Flex>
+            <StatusIcon status={StatusType.Loading} label={PlanStatusDisplayType.Initializing} />
           ) : isStatusReady ? (
             <StatusIcon status={StatusType.Ok} label={PlanStatusDisplayType.Ready} />
           ) : (

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -251,9 +251,9 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                   </FlexItem>
                 </Flex>
               </>
-            ) : (
+            ) : !isInitializing ? (
               <PlanActionsDropdown conditions={conditions} />
-            ),
+            ) : null,
         },
       ],
     });

--- a/src/app/Plans/components/Step.tsx
+++ b/src/app/Plans/components/Step.tsx
@@ -23,7 +23,7 @@ interface IStepProps {
 const Step: React.FunctionComponent<IStepProps> = ({ status, index }: IStepProps) => {
   const { currentStepIndex } = findCurrentStep(status.pipeline);
   const step = status.pipeline[index];
-  if (status.completed || step?.completed) {
+  if (status.completed || step?.completed || index < currentStepIndex) {
     return (
       <ResourcesFullIcon
         className={spacing.mlSm}

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -160,6 +160,11 @@ const VMMigrationDetails: React.FunctionComponent = () => {
 
   const rows: IRow[] = [];
 
+  const getVMStatus = (vmStatus) => {
+    console.log('vmStatus:', vmStatus);
+    return vmStatus;
+  };
+
   currentPageItems.forEach((vmStatus: IVMStatus) => {
     const isExpanded = isVMExpanded(vmStatus);
 
@@ -174,7 +179,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         formatTimestamp(vmStatus.completed),
         `${Math.round(ratio.completed / 1024)} / ${Math.round(ratio.total / 1024)} GB`,
         {
-          title: <PipelineSummary status={vmStatus} />,
+          title: <PipelineSummary status={getVMStatus(vmStatus)} />,
         },
       ],
     });

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -36,6 +36,7 @@ export enum PlanStatusDisplayType {
   Executing = 'Running',
   Succeeded = 'Succeeded',
   Failed = 'Failed',
+  Initializing = 'Initializing',
 }
 
 export enum MigrationVMStepsType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -539,9 +539,9 @@
     chalk "^4.0.0"
 
 "@konveyor/lib-ui@^1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-1.8.2.tgz#7d52a08b444d96f65811fa55f27b37729c0c0f95"
-  integrity sha512-Qt3DJJiUufj6XEJjzsriu0O4jg0QsKmcoFQn+40UzZgjmDk4FI9nvUidxd+cyxL+3pU8gYg1Va8xFGqv3xLYwQ==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-1.9.0.tgz#6335f6c9607c5d0c67f328feba28e1816a79c8d8"
+  integrity sha512-SbEAM7KAkWWksPxicQJ8qxyoklGjgIeXk7iK5Y6bN2Vx0aH8ZpQ5JzBS15PPck2PYes/oPGlbbi2L50HT5xeSw==
   dependencies:
     fast-deep-equal "^3.1.3"
     yup "^0.29.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,7 +538,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@konveyor/lib-ui@^1.8.2":
+"@konveyor/lib-ui@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-1.9.0.tgz#6335f6c9607c5d0c67f328feba28e1816a79c8d8"
   integrity sha512-SbEAM7KAkWWksPxicQJ8qxyoklGjgIeXk7iK5Y6bN2Vx0aH8ZpQ5JzBS15PPck2PYes/oPGlbbi2L50HT5xeSw==


### PR DESCRIPTION
Takes care of a newly migration plans to display Spinner with a "Initializing" status before the backend catches up.

![spin](https://user-images.githubusercontent.com/1901741/97579888-e59d3f80-19f2-11eb-98dd-9f9113a1f246.gif)