### PR TITLE
Add proper form field validation based on real API expectations

### DIFF
--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -33,6 +33,7 @@ import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 import './AddEditMappingModal.css';
 import MutationStatus from '@app/common/components/MutationStatus';
+import { dnsLabelNameSchema } from '@app/common/constants';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -49,7 +50,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
 
   // TODO add support for prefilling form for editing an API mapping
   const form = useFormState({
-    name: useFormField('', yup.string().label('Mapping name').required()),
+    name: useFormField('', dnsLabelNameSchema.label('Mapping name').required()),
     sourceProvider: useFormField<IVMwareProvider | null>(
       null,
       yup.mixed<IVMwareProvider>().label('Source provider').required()

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -27,13 +27,14 @@ import {
   useProvidersQuery,
   useMappingResourceQueries,
   useCreateMappingMutation,
+  getMappingNameSchema,
+  useMappingsQuery,
 } from '@app/queries';
 import { usePausedPollingEffect } from '@app/common/context';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 import './AddEditMappingModal.css';
 import MutationStatus from '@app/common/components/MutationStatus';
-import { dnsLabelNameSchema } from '@app/common/constants';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -48,9 +49,11 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
 }: IAddEditMappingModalProps) => {
   usePausedPollingEffect();
 
+  const mappingsQuery = useMappingsQuery(mappingType);
+
   // TODO add support for prefilling form for editing an API mapping
   const form = useFormState({
-    name: useFormField('', dnsLabelNameSchema.label('Mapping name').required()),
+    name: useFormField('', getMappingNameSchema(mappingsQuery).label('Mapping name').required()),
     sourceProvider: useFormField<IVMwareProvider | null>(
       null,
       yup.mixed<IVMwareProvider>().label('Source provider').required()

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as yup from 'yup';
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Level,
@@ -21,6 +22,7 @@ import Review from './Review';
 import MappingForm from './MappingForm';
 import {
   IOpenShiftProvider,
+  IPlan,
   IVMwareProvider,
   IVMwareVM,
   Mapping,
@@ -34,15 +36,17 @@ import {
   mappingBuilderItemsSchema,
 } from '@app/Mappings/components/MappingBuilder';
 import { generateMappings, generatePlan } from './helpers';
-import { useCreatePlanMutation } from '@app/queries/plans';
-import { useCreateMappingMutation } from '@app/queries';
+import { getPlanNameSchema, useCreatePlanMutation, usePlansQuery } from '@app/queries/plans';
+import { getMappingNameSchema, useCreateMappingMutation, useMappingsQuery } from '@app/queries';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
-import { QueryStatus } from 'react-query';
+import { QueryResult, QueryStatus } from 'react-query';
 import { dnsLabelNameSchema } from '@app/common/constants';
+import { IKubeList } from '@app/client/types';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
-const useMappingFormState = () => {
+const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
-  const newMappingNameSchema = dnsLabelNameSchema.label('Name');
+  const newMappingNameSchema = getMappingNameSchema(mappingsQuery).label('Name');
   return useFormState({
     isCreateMappingSelected: useFormField(false, yup.boolean().required()),
     selectedExistingMapping: useFormField<Mapping | null>(null, yup.mixed<Mapping>()),
@@ -56,9 +60,13 @@ const useMappingFormState = () => {
 };
 
 // TODO add support for prefilling forms for editing an API plan
-const usePlanWizardFormState = () => ({
+const usePlanWizardFormState = (
+  plansQuery: QueryResult<IKubeList<IPlan>>,
+  networkMappingsQuery: QueryResult<IKubeList<Mapping>>,
+  storageMappingsQuery: QueryResult<IKubeList<Mapping>>
+) => ({
   general: useFormState({
-    planName: useFormField('', dnsLabelNameSchema.label('Plan name').required()),
+    planName: useFormField('', getPlanNameSchema(plansQuery).label('Plan name').required()),
     planDescription: useFormField('', yup.string().label('Plan description').defined()),
     sourceProvider: useFormField<IVMwareProvider | null>(
       null,
@@ -77,8 +85,8 @@ const usePlanWizardFormState = () => ({
   selectVMs: useFormState({
     selectedVMs: useFormField<IVMwareVM[]>([], yup.array<IVMwareVM>().required()),
   }),
-  networkMapping: useMappingFormState(),
-  storageMapping: useMappingFormState(),
+  networkMapping: useMappingFormState(networkMappingsQuery),
+  storageMapping: useMappingFormState(storageMappingsQuery),
 });
 
 export type PlanWizardFormState = ReturnType<typeof usePlanWizardFormState>; // ✨ Magic
@@ -86,7 +94,10 @@ export type PlanWizardFormState = ReturnType<typeof usePlanWizardFormState>; // 
 const PlanWizard: React.FunctionComponent = () => {
   usePausedPollingEffect(); // Polling can interfere with form state
   const history = useHistory();
-  const forms = usePlanWizardFormState();
+  const plansQuery = usePlansQuery();
+  const networkMappingsQuery = useMappingsQuery(MappingType.Network);
+  const storageMappingsQuery = useMappingsQuery(MappingType.Storage);
+  const forms = usePlanWizardFormState(plansQuery, networkMappingsQuery, storageMappingsQuery);
 
   enum StepId {
     General = 1,
@@ -274,6 +285,16 @@ const PlanWizard: React.FunctionComponent = () => {
   const isSomeFormDirty = (Object.keys(forms) as (keyof PlanWizardFormState)[]).some(
     (key) => forms[key].isDirty
   );
+
+  if (plansQuery.isLoading || networkMappingsQuery.isLoading || storageMappingsQuery.isLoading) {
+    return <LoadingEmptyState />;
+  }
+  if (plansQuery.isError) {
+    return <Alert variant="danger" title="Error loading plans" />;
+  }
+  if (networkMappingsQuery.isError || storageMappingsQuery.isError) {
+    return <Alert variant="danger" title="Error loading mappings" />;
+  }
 
   return (
     <>

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -38,10 +38,11 @@ import { useCreatePlanMutation } from '@app/queries/plans';
 import { useCreateMappingMutation } from '@app/queries';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
 import { QueryStatus } from 'react-query';
+import { dnsLabelNameSchema } from '@app/common/constants';
 
 const useMappingFormState = () => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
-  const newMappingNameSchema = yup.string().label('Name');
+  const newMappingNameSchema = dnsLabelNameSchema.label('Name');
   return useFormState({
     isCreateMappingSelected: useFormField(false, yup.boolean().required()),
     selectedExistingMapping: useFormField<Mapping | null>(null, yup.mixed<Mapping>()),
@@ -57,7 +58,7 @@ const useMappingFormState = () => {
 // TODO add support for prefilling forms for editing an API plan
 const usePlanWizardFormState = () => ({
   general: useFormState({
-    planName: useFormField('', yup.string().label('Plan name').required()),
+    planName: useFormField('', dnsLabelNameSchema.label('Plan name').required()),
     planDescription: useFormField('', yup.string().label('Plan description').defined()),
     sourceProvider: useFormField<IVMwareProvider | null>(
       null,
@@ -67,7 +68,7 @@ const usePlanWizardFormState = () => ({
       null,
       yup.mixed<IOpenShiftProvider>().label('Target provider').required()
     ),
-    targetNamespace: useFormField('', yup.string().label('Target namespace').required()),
+    targetNamespace: useFormField('', dnsLabelNameSchema.label('Target namespace').required()),
   }),
   filterVMs: useFormState({
     treeType: useFormField<VMwareTreeType>(VMwareTreeType.Host, yup.mixed<VMwareTreeType>()),

--- a/src/app/Providers/components/AddProviderModal/AddProviderModal.tsx
+++ b/src/app/Providers/components/AddProviderModal/AddProviderModal.tsx
@@ -9,7 +9,12 @@ import {
 } from '@konveyor/lib-ui';
 
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import { ProviderType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
+import {
+  dnsLabelNameSchema,
+  ProviderType,
+  PROVIDER_TYPE_NAMES,
+  urlSchema,
+} from '@app/common/constants';
 import { usePausedPollingEffect } from '@app/common/context';
 import { useCreateProviderMutation } from '@app/queries';
 import MutationStatus from '@app/common/components/MutationStatus';
@@ -34,17 +39,17 @@ const useAddProviderFormState = () => {
   return {
     [ProviderType.vsphere]: useFormState({
       providerType: providerTypeField,
-      name: useFormField('', yup.string().label('Name').required()),
-      hostname: useFormField('', yup.string().label('Hostname').required()),
-      username: useFormField('', yup.string().label('Username').required()),
-      password: useFormField('', yup.string().label('Password').required()),
+      name: useFormField('', dnsLabelNameSchema.label('Name').required()),
+      hostname: useFormField('', yup.string().max(255).label('Hostname').required()),
+      username: useFormField('', yup.string().max(320).label('Username').required()),
+      password: useFormField('', yup.string().max(256).label('Password').required()),
       fingerprint: useFormField('', yup.string().label('Certificate SHA1 Fingerprint').required()),
       fingerprintFilename: useFormField('', yup.string()),
     }),
     [ProviderType.openshift]: useFormState({
       providerType: providerTypeField,
-      clusterName: useFormField('', yup.string().label('Cluster name').required()),
-      url: useFormField('', yup.string().label('URL').required()),
+      clusterName: useFormField('', dnsLabelNameSchema.label('Cluster name').required()),
+      url: useFormField('', urlSchema.label('URL').required()),
       saToken: useFormField('', yup.string().label('Service account token').required()),
     }),
   };

--- a/src/app/Providers/components/AddProviderModal/AddProviderModal.tsx
+++ b/src/app/Providers/components/AddProviderModal/AddProviderModal.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import * as yup from 'yup';
-import { Modal, Button, Form, FormGroup, Flex, Stack, FileUpload } from '@patternfly/react-core';
+import {
+  Modal,
+  Button,
+  Form,
+  FormGroup,
+  Flex,
+  Stack,
+  FileUpload,
+  Alert,
+} from '@patternfly/react-core';
 import {
   useFormState,
   useFormField,
@@ -9,17 +18,15 @@ import {
 } from '@konveyor/lib-ui';
 
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import {
-  dnsLabelNameSchema,
-  ProviderType,
-  PROVIDER_TYPE_NAMES,
-  urlSchema,
-} from '@app/common/constants';
+import { ProviderType, PROVIDER_TYPE_NAMES, urlSchema } from '@app/common/constants';
 import { usePausedPollingEffect } from '@app/common/context';
-import { useCreateProviderMutation } from '@app/queries';
+import { getProviderNameSchema, useCreateProviderMutation, useProvidersQuery } from '@app/queries';
 import MutationStatus from '@app/common/components/MutationStatus';
 
 import './AddProviderModal.css';
+import { IProvidersByType } from '@app/queries/types';
+import { QueryResult } from 'react-query';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 interface IAddProviderModalProps {
   onClose: () => void;
@@ -30,7 +37,7 @@ const PROVIDER_TYPE_OPTIONS = Object.values(ProviderType).map((type) => ({
   value: type,
 })) as OptionWithValue<ProviderType>[];
 
-const useAddProviderFormState = () => {
+const useAddProviderFormState = (providersQuery: QueryResult<IProvidersByType>) => {
   // TODO determine the actual validation criteria for this form -- these are for testing
   const providerTypeField = useFormField<ProviderType | null>(
     null,
@@ -39,7 +46,10 @@ const useAddProviderFormState = () => {
   return {
     [ProviderType.vsphere]: useFormState({
       providerType: providerTypeField,
-      name: useFormField('', dnsLabelNameSchema.label('Name').required()),
+      name: useFormField(
+        '',
+        getProviderNameSchema(providersQuery, ProviderType.vsphere).label('Name').required()
+      ),
       hostname: useFormField('', yup.string().max(255).label('Hostname').required()),
       username: useFormField('', yup.string().max(320).label('Username').required()),
       password: useFormField('', yup.string().max(256).label('Password').required()),
@@ -48,7 +58,12 @@ const useAddProviderFormState = () => {
     }),
     [ProviderType.openshift]: useFormState({
       providerType: providerTypeField,
-      clusterName: useFormField('', dnsLabelNameSchema.label('Cluster name').required()),
+      clusterName: useFormField(
+        '',
+        getProviderNameSchema(providersQuery, ProviderType.openshift)
+          .label('Cluster name')
+          .required()
+      ),
       url: useFormField('', urlSchema.label('URL').required()),
       saToken: useFormField('', yup.string().label('Service account token').required()),
     }),
@@ -65,7 +80,9 @@ const AddProviderModal: React.FunctionComponent<IAddProviderModalProps> = ({
 }: IAddProviderModalProps) => {
   usePausedPollingEffect();
 
-  const forms = useAddProviderFormState();
+  const providersQuery = useProvidersQuery();
+
+  const forms = useAddProviderFormState(providersQuery);
   const vmwareForm = forms[ProviderType.vsphere];
   const openshiftForm = forms[ProviderType.openshift];
   const providerTypeField = vmwareForm.fields.providerType;
@@ -111,98 +128,103 @@ const AddProviderModal: React.FunctionComponent<IAddProviderModalProps> = ({
         </Stack>
       }
     >
-      <Form>
-        <FormGroup
-          label="Type"
-          isRequired
-          fieldId="provider-type"
-          className={!providerType ? 'extraSelectMargin' : ''}
-          {...getFormGroupProps(providerTypeField)}
-        >
-          <SimpleSelect
-            id="provider-type"
-            aria-label="Provider type"
-            options={PROVIDER_TYPE_OPTIONS}
-            value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
-            onChange={(selection) => {
-              providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
-              providerTypeField.setIsTouched(true);
-            }}
-            placeholderText="Select a provider type..."
-          />
-        </FormGroup>
-        {providerType === ProviderType.vsphere ? (
-          <>
-            <ValidatedTextInput
-              field={vmwareForm.fields.name}
-              label="Name"
-              isRequired
-              fieldId="vmware-name"
+      {providersQuery.isLoading ? (
+        <LoadingEmptyState />
+      ) : providersQuery.isError ? (
+        <Alert variant="danger" isInline title="Error loading providers" />
+      ) : (
+        <Form>
+          <FormGroup
+            label="Type"
+            isRequired
+            fieldId="provider-type"
+            className={!providerType ? 'extraSelectMargin' : ''}
+            {...getFormGroupProps(providerTypeField)}
+          >
+            <SimpleSelect
+              id="provider-type"
+              aria-label="Provider type"
+              options={PROVIDER_TYPE_OPTIONS}
+              value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
+              onChange={(selection) => {
+                providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
+                providerTypeField.setIsTouched(true);
+              }}
+              placeholderText="Select a provider type..."
             />
-            <ValidatedTextInput
-              field={vmwareForm.fields.hostname}
-              label="Hostname"
-              isRequired
-              fieldId="vmware-hostname"
-            />
-            <ValidatedTextInput
-              field={vmwareForm.fields.username}
-              label="Username"
-              isRequired
-              fieldId="vmware-username"
-            />
-            <ValidatedTextInput
-              field={vmwareForm.fields.password}
-              type="password"
-              label="Password"
-              isRequired
-              fieldId="vmware-password"
-            />
-            <FormGroup
-              label="Certificate SHA1 Fingerprint"
-              isRequired
-              fieldId="fingerprint"
-              {...getFormGroupProps(vmwareForm.fields.fingerprint)}
-            >
-              <FileUpload
-                id="fingerprint"
-                type="text"
-                value={vmwareForm.values.fingerprint}
-                filename={vmwareForm.values.fingerprintFilename}
-                onChange={(value, filename) => {
-                  vmwareForm.fields.fingerprint.setValue(value as string);
-                  vmwareForm.fields.fingerprintFilename.setValue(filename);
-                }}
-                onBlur={() => vmwareForm.fields.fingerprint.setIsTouched(true)}
-                validated={vmwareForm.fields.fingerprint.isValid ? 'default' : 'error'}
+          </FormGroup>
+          {providerType === ProviderType.vsphere ? (
+            <>
+              <ValidatedTextInput
+                field={vmwareForm.fields.name}
+                label="Name"
+                isRequired
+                fieldId="vmware-name"
               />
-            </FormGroup>
-          </>
-        ) : null}
-        {providerType === ProviderType.openshift ? (
-          <>
-            <ValidatedTextInput
-              field={openshiftForm.fields.clusterName}
-              label="Cluster name"
-              isRequired
-              fieldId="openshift-cluster-name"
-            />
-            <ValidatedTextInput
-              field={openshiftForm.fields.url}
-              label="URL"
-              isRequired
-              fieldId="openshift-url"
-            />
-            <ValidatedTextInput
-              field={openshiftForm.fields.saToken}
-              type="password"
-              label="Service account token"
-              isRequired
-              fieldId="openshift-sa-token"
-            />
-          </>
-        ) : null}
-        {/* TODO re-enable this when we have the API capability
+              <ValidatedTextInput
+                field={vmwareForm.fields.hostname}
+                label="Hostname"
+                isRequired
+                fieldId="vmware-hostname"
+              />
+              <ValidatedTextInput
+                field={vmwareForm.fields.username}
+                label="Username"
+                isRequired
+                fieldId="vmware-username"
+              />
+              <ValidatedTextInput
+                field={vmwareForm.fields.password}
+                type="password"
+                label="Password"
+                isRequired
+                fieldId="vmware-password"
+              />
+              <FormGroup
+                label="Certificate SHA1 Fingerprint"
+                isRequired
+                fieldId="fingerprint"
+                {...getFormGroupProps(vmwareForm.fields.fingerprint)}
+              >
+                <FileUpload
+                  id="fingerprint"
+                  type="text"
+                  value={vmwareForm.values.fingerprint}
+                  filename={vmwareForm.values.fingerprintFilename}
+                  onChange={(value, filename) => {
+                    vmwareForm.fields.fingerprint.setValue(value as string);
+                    vmwareForm.fields.fingerprintFilename.setValue(filename);
+                  }}
+                  onBlur={() => vmwareForm.fields.fingerprint.setIsTouched(true)}
+                  validated={vmwareForm.fields.fingerprint.isValid ? 'default' : 'error'}
+                />
+              </FormGroup>
+            </>
+          ) : null}
+          {providerType === ProviderType.openshift ? (
+            <>
+              <ValidatedTextInput
+                field={openshiftForm.fields.clusterName}
+                label="Cluster name"
+                isRequired
+                fieldId="openshift-cluster-name"
+              />
+              <ValidatedTextInput
+                field={openshiftForm.fields.url}
+                label="URL"
+                isRequired
+                fieldId="openshift-url"
+              />
+              <ValidatedTextInput
+                field={openshiftForm.fields.saToken}
+                type="password"
+                label="Service account token"
+                isRequired
+                fieldId="openshift-sa-token"
+              />
+            </>
+          ) : null}
+          {/* TODO re-enable this when we have the API capability
         providerType ? (
           <div>
             <Button variant="link" isInline icon={<ConnectedIcon />} onClick={() => alert('TODO')}>
@@ -211,7 +233,8 @@ const AddProviderModal: React.FunctionComponent<IAddProviderModalProps> = ({
           </div>
         ) : null
         */}
-      </Form>
+        </Form>
+      )}
     </Modal>
   );
 };

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -46,8 +46,8 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   onClose,
 }: ISelectNetworkModalProps) => {
   const form = useFormState({
-    adminUserId: useFormField('', yup.string().label('User Id').required()),
-    adminPassword: useFormField('', yup.string().label('Password').required()),
+    adminUserId: useFormField('', yup.string().max(320).label('User Id').required()),
+    adminPassword: useFormField('', yup.string().max(256).label('Password').required()),
     selectedNetwork: useFormField(null, yup.mixed<IHostNetwork>().label('Host network').required()),
   });
 

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -1,3 +1,5 @@
+import * as yup from 'yup';
+
 import { IVirtMetaVars } from './types';
 
 export const APP_TITLE = 'Migration Toolkit for Virtualization';
@@ -71,3 +73,21 @@ export const VIRT_META: IVirtMetaVars =
         configNamespace: 'mock-namespace',
         inventoryApi: '/mock/api',
       };
+
+export const dnsLabelNameSchema = yup
+  .string()
+  .max(63)
+  .matches(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+    ({ label }) =>
+      `${label} can only contain lowercase alphanumeric characters and dashes (-), and must start and end with an alphanumeric character`
+  );
+
+export const urlSchema = yup.string().test('is-valid-url', 'Must be a valid URL', (value) => {
+  try {
+    new URL(value as string);
+  } catch (_) {
+    return false;
+  }
+  return true;
+});

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -1,4 +1,5 @@
 import { MutationResultPair, useQueryCache, QueryResult, QueryStatus } from 'react-query';
+import * as yup from 'yup';
 import {
   IVMwareProvider,
   IOpenShiftProvider,
@@ -25,7 +26,7 @@ import {
   VirtResource,
   VirtResourceKind,
 } from '@app/client/helpers';
-import { VIRT_META } from '@app/common/constants';
+import { dnsLabelNameSchema, VIRT_META } from '@app/common/constants';
 import { KubeClientError, IKubeList } from '@app/client/types';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mocks/mappings.mock';
 import { usePollingContext } from '@app/common/context';
@@ -138,3 +139,11 @@ export const useMappingResourceQueries = (
     error,
   };
 };
+
+export const getMappingNameSchema = (
+  mappingsQuery: QueryResult<IKubeList<Mapping>>
+): yup.StringSchema =>
+  dnsLabelNameSchema.test('unique-name', 'A mapping with this name already exists', (value) => {
+    if (mappingsQuery.data?.items.find((mapping) => mapping.metadata.name === value)) return false;
+    return true;
+  });

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -1,3 +1,4 @@
+import * as yup from 'yup';
 import {
   checkIfResourceExists,
   useClientInstance,
@@ -5,7 +6,7 @@ import {
   VirtResourceKind,
 } from '@app/client/helpers';
 import { IKubeList, KubeClientError } from '@app/client/types';
-import { VIRT_META } from '@app/common/constants';
+import { dnsLabelNameSchema, VIRT_META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
 import { MutationResultPair, QueryResult, useQueryCache } from 'react-query';
 import { POLLING_INTERVAL } from './constants';
@@ -51,3 +52,9 @@ export const useCreatePlanMutation = (
     }
   );
 };
+
+export const getPlanNameSchema = (plansQuery: QueryResult<IKubeList<IPlan>>): yup.StringSchema =>
+  dnsLabelNameSchema.test('unique-name', 'A plan with this name already exists', (value) => {
+    if (plansQuery.data?.items.find((plan) => plan.metadata.name === value)) return false;
+    return true;
+  });

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -1,4 +1,5 @@
 import { useQueryCache, QueryResult, MutationResultPair } from 'react-query';
+import * as yup from 'yup';
 
 import { usePollingContext } from '@app/common/context';
 import { POLLING_INTERVAL } from './constants';
@@ -30,7 +31,7 @@ import {
   useClientInstance,
 } from '@app/client/helpers';
 import { AddProviderFormValues } from '@app/Providers/components/AddProviderModal/AddProviderModal';
-import { ProviderType } from '@app/common/constants';
+import { dnsLabelNameSchema, ProviderType } from '@app/common/constants';
 import { KubeClientError } from '@app/client/types';
 
 // TODO handle error messages? (query.status will correctly show 'error', but error messages aren't collected)
@@ -178,3 +179,13 @@ export const findProvidersByRefs = (
     null;
   return { sourceProvider, targetProvider };
 };
+
+export const getProviderNameSchema = (
+  providersQuery: QueryResult<IProvidersByType>,
+  providerType: ProviderType
+): yup.StringSchema =>
+  dnsLabelNameSchema.test('unique-name', 'A provider with this name already exists', (value) => {
+    const providers: Provider[] = (providersQuery.data && providersQuery.data[providerType]) || [];
+    if (providers.find((provider) => provider.name === value)) return false;
+    return true;
+  });


### PR DESCRIPTION
Resolves #157 
Resolves #128 

Implements guidance from @fdupont-redhat on how to validate our text fields. Also prevents users from creating providers/mappings/plans with a name that is already in use.

Still waiting on a couple of unknowns in https://github.com/konveyor/virt-ui/issues/157#issuecomment-717542095.