### PR TITLE
set up a custom wrapper to handle axios responses from the k8s client…

### DIFF
--- a/src/app/common/context/NetworkContext.tsx
+++ b/src/app/common/context/NetworkContext.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { LocalStorageKey, useLocalStorageContext } from './LocalStorageContext';
 import { AxiosError } from 'axios';
 import { History } from 'history';
-import { setTokenExpiryHandler } from '@konveyor/lib-ui';
 
 export interface INetworkContext {
   setSelfSignedCertUrl: (url: string) => void;
@@ -40,11 +39,6 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
     setCurrentUser(JSON.stringify(user));
     history.push('/');
   };
-  // handle expiry for axios calls using k8s client
-  setTokenExpiryHandler(() => {
-    console.error('token expired');
-    setCurrentUser('');
-  });
 
   const checkExpiry = (error: Response | AxiosError<unknown>, history: History) => {
     const status = (error as Response).status || (error as AxiosError<unknown>).response?.status;

--- a/src/app/common/context/NetworkContext.tsx
+++ b/src/app/common/context/NetworkContext.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { LocalStorageKey, useLocalStorageContext } from './LocalStorageContext';
 import { AxiosError } from 'axios';
 import { History } from 'history';
+import { setTokenExpiryHandler } from '@konveyor/lib-ui';
 
 export interface INetworkContext {
   setSelfSignedCertUrl: (url: string) => void;
@@ -39,6 +40,11 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
     setCurrentUser(JSON.stringify(user));
     history.push('/');
   };
+  // handle expiry for axios calls using k8s client
+  setTokenExpiryHandler(() => {
+    console.error('token expired');
+    setCurrentUser('');
+  });
 
   const checkExpiry = (error: Response | AxiosError<unknown>, history: History) => {
     const status = (error as Response).status || (error as AxiosError<unknown>).response?.status;

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -97,7 +97,7 @@ export const useAuthorizedFetch = <T>(url: string): QueryFunction<T> => {
   return () => authorizedFetch(url, fetchContext);
 };
 
-export const useAuthorizedK8sFetch = <T>(resourceType: any): QueryFunction<T> => {
+export const useAuthorizedK8sFetch = <T>(resourceType: KubeResource): QueryFunction<T> => {
   const fetchContext = useFetchContext();
   const client = useClientInstance();
   return () => authorizedK8sFetch(resourceType, fetchContext, client);

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -3,6 +3,8 @@ import { INetworkContext, useNetworkContext } from '@app/common/context/NetworkC
 import { QueryFunction, MutateFunction } from 'react-query/types/core/types';
 import { useHistory } from 'react-router-dom';
 import { History, LocationState } from 'history';
+import { useClientInstance } from '@app/client/helpers';
+import { ClusterClient, KubeResource } from '@konveyor/lib-ui';
 
 interface IFetchContext {
   history: History<LocationState>;
@@ -49,6 +51,41 @@ export const authorizedFetch = async <T>(
   }
 };
 
+export const authorizedK8sFetch = async <T>(
+  resourceType: KubeResource,
+  fetchContext: IFetchContext,
+  client: ClusterClient
+): Promise<T> => {
+  const { history, setSelfSignedCertUrl, checkExpiry } = fetchContext;
+
+  try {
+    const response = await client.list(resourceType);
+
+    if (response && response.data) {
+      return response.data;
+    } else {
+      throw response;
+    }
+  } catch (error) {
+    checkExpiry(error, history);
+
+    const isAxiosSelfSignedCertError = (err) => {
+      // HACK: Doing our best to determine whether or not the
+      // error was produced due to a self signed cert error.
+      // It's an extremely barren object.
+      const e = err.toJSON();
+      return !e.code && e.message === 'Network Error';
+    };
+
+    if (isAxiosSelfSignedCertError(error)) {
+      const url = `${VIRT_META.clusterApi}/.well-known/oauth-authorization-server`;
+      setSelfSignedCertUrl(url);
+      history.push('/cert-error');
+    }
+    throw error;
+  }
+};
+
 export const authorizedPost = async <T, TData>(
   url: string,
   fetchContext: IFetchContext,
@@ -58,6 +95,12 @@ export const authorizedPost = async <T, TData>(
 export const useAuthorizedFetch = <T>(url: string): QueryFunction<T> => {
   const fetchContext = useFetchContext();
   return () => authorizedFetch(url, fetchContext);
+};
+
+export const useAuthorizedK8sFetch = <T>(resourceType: any): QueryFunction<T> => {
+  const fetchContext = useFetchContext();
+  const client = useClientInstance();
+  return () => authorizedK8sFetch(resourceType, fetchContext, client);
 };
 
 export const useAuthorizedPost = <T, TData>(url: string, data: TData): MutateFunction<T, TData> => {

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -30,6 +30,7 @@ import { KubeClientError, IKubeList } from '@app/client/types';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mocks/mappings.mock';
 import { usePollingContext } from '@app/common/context';
 import { POLLING_INTERVAL } from './constants';
+import { useAuthorizedK8sFetch } from './fetchHelpers';
 
 const getMappingResource = (mappingType: MappingType) => {
   const kind =
@@ -43,10 +44,7 @@ export const useMappingsQuery = (mappingType: MappingType): QueryResult<IKubeLis
   const result = useMockableQuery<IKubeList<Mapping>>(
     {
       queryKey: ['mappings', mappingType],
-      queryFn: async () => {
-        const { resource } = getMappingResource(mappingType);
-        return (await client.list(resource)).data;
-      },
+      queryFn: useAuthorizedK8sFetch(getMappingResource(mappingType).resource),
       config: { refetchInterval: usePollingContext().isPollingEnabled ? POLLING_INTERVAL : false },
     },
     mappingType === MappingType.Network

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -28,9 +28,6 @@ export const usePlansQuery = (): QueryResult<IKubeList<IPlan>> => {
       queryFn: useAuthorizedK8sFetch(planResource),
       config: {
         refetchInterval: usePollingContext().isPollingEnabled ? POLLING_INTERVAL : false,
-        onError: (error) => {
-          console.log('error', error);
-        },
       },
     },
     mockKubeList(MOCK_PLANS, 'Plan')

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -17,16 +17,21 @@ import {
 } from './helpers';
 import { MOCK_PLANS } from './mocks/plans.mock';
 import { IPlan } from './types';
+import { useAuthorizedK8sFetch } from './fetchHelpers';
 
 const planResource = new VirtResource(VirtResourceKind.Plan, VIRT_META.namespace);
 
 export const usePlansQuery = (): QueryResult<IKubeList<IPlan>> => {
-  const client = useClientInstance();
   const result = useMockableQuery<IKubeList<IPlan>>(
     {
       queryKey: 'plans',
-      queryFn: async () => (await client.list(planResource)).data,
-      config: { refetchInterval: usePollingContext().isPollingEnabled ? POLLING_INTERVAL : false },
+      queryFn: useAuthorizedK8sFetch(planResource),
+      config: {
+        refetchInterval: usePollingContext().isPollingEnabled ? POLLING_INTERVAL : false,
+        onError: (error) => {
+          console.log('error', error);
+        },
+      },
     },
     mockKubeList(MOCK_PLANS, 'Plan')
   );


### PR DESCRIPTION
This PR handles errors from axios which are formatted differently than fetch errors. 

Any time we are fetching from the k8s client, we can pass in ```        queryFn: useAuthorizedK8sFetch(planResource),```  as the query function for useMockableQuery. This will handle the SSL issues & token expiry issues for requests against the clusterApi url.