### PR TITLE
Enable TLS for UI

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const express = require('express');
+const https = require('https');
 const fs = require('fs');
 const dayjs = require('dayjs');
 
@@ -20,6 +21,10 @@ const virtMeta = JSON.parse(virtMetaStr);
 const app = express();
 const port = process.env['EXPRESS_PORT'] || 8080;
 const staticDir = process.env['STATIC_DIR'] || path.join(__dirname, '../dist');
+const options = {
+  key: fs.readFileSync("/var/run/secrets/migration-ui-tls/tls.key"),
+  cert: fs.readFileSync("/var/run/secrets/migration-ui-tls/tls.crt")
+};
 
 app.engine('ejs', require('ejs').renderFile);
 app.use(express.static(staticDir));
@@ -80,3 +85,4 @@ app.get('*', (req, res) => {
 });
 
 app.listen(port, () => console.log(`Listening on port ${port}`));
+https.createServer(options, app).listen(8443);

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -21,10 +21,6 @@ const virtMeta = JSON.parse(virtMetaStr);
 const app = express();
 const port = process.env['EXPRESS_PORT'] || 8080;
 const staticDir = process.env['STATIC_DIR'] || path.join(__dirname, '../dist');
-const options = {
-  key: fs.readFileSync("/var/run/secrets/migration-ui-tls/tls.key"),
-  cert: fs.readFileSync("/var/run/secrets/migration-ui-tls/tls.crt")
-};
 
 app.engine('ejs', require('ejs').renderFile);
 app.use(express.static(staticDir));
@@ -84,5 +80,12 @@ app.get('*', (req, res) => {
   }
 });
 
-app.listen(port, () => console.log(`Listening on port ${port}`));
-https.createServer(options, app).listen(8443);
+if (process.env['NODE_ENV'] !== 'development' && process.env['DATA_SOURCE'] !== 'mock') {
+  const options = {
+    key: fs.readFileSync('/var/run/secrets/migration-ui-tls/tls.key'),
+    cert: fs.readFileSync('/var/run/secrets/migration-ui-tls/tls.crt'),
+  };
+  https.createServer(options, app).listen(8443);
+} else {
+  app.listen(port, () => console.log(`Listening on port ${port}`));
+}


### PR DESCRIPTION
This pull request enable TLS for the UI container. The certificate and key are provided by a secret automatically generated by the openshift-service-serving-signer, so the CA certificate chain is mounted in every pod as `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. The secret is mounted in a hardcoded path based on the secret name.

More information on using service serving certificates is available at [OpenShift > Security and compliance > Configuring certificates > Securing service traffic using service serving certificate secrets](https://docs.openshift.com/container-platform/4.6/security/certificates/service-serving-certificate.html).

The deployment, service and route are modified in [konveyor/virt-operator#30](https://github.com/konveyor/virt-operator/pull/30)