### PR TITLE
Encode all fields of secrets in base64

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -72,13 +72,15 @@ export function convertFormValuesToSecret(
   } else {
     // default to vmware
     const vmwareValues = values as VMwareProviderFormValues;
+    const encodedUser = btoa(vmwareValues.username);
     const encodedPassword = btoa(vmwareValues.password);
+    const encodedThumbprint = btoa(vmwareValues.fingerprint);
     return {
       apiVersion: 'v1',
       data: {
-        user: vmwareValues.username,
+        user: encodedUser,
         password: encodedPassword,
-        thumbprint: vmwareValues.fingerprint,
+        thumbprint: encodedThumbprint,
       },
       kind: 'Secret',
       metadata: {


### PR DESCRIPTION
In a secret, it's not possible to mix data formats between clear text and base64. This pull request encodes the `user` and `thumbprint` fields to be consistent with the other encoded fields.

Another option would be to use a `stringData` section instead of `data` and let all fields in clear text. The field would be encoded dynamically during secret creation.

Without that the secret cannot be created and the UI throws the following error:

![20201030-ProviderSecretError](https://user-images.githubusercontent.com/25821288/97706183-8a805100-1ab5-11eb-919c-cebbfc0e9cec.png)