### PR TITLE
Generate VMware provider URL from hostname

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -105,7 +105,7 @@ export const convertFormValuesToProvider = (
   if (providerType === 'vsphere') {
     const vmwareValues = values as VMwareProviderFormValues;
     name = vmwareValues.name;
-    url = vmwareValues.hostname;
+    url = 'https://' + vmwareValues.hostname + '/sdk';
   } else {
     const openshiftValues = values as OpenshiftProviderFormValues;
     name = openshiftValues.clusterName;


### PR DESCRIPTION
In the VMware provider creation wizard, the field _Hostname_ is passed as is as the `url` field of the Provider CR.
The URL must really be the VMware SDK URL: https://<hostname>/sdk.
Tests have shown that the current implementation creates a provider that cannot be inventoried, because the URL cannot be reached: no scheme and API endpoint missing.

This pull request generates the URL from the hostname when creating the Provider CR.