### PR TITLE
Refactor Step and PipelineSummary to rely on common VM status logic

### DIFF
--- a/src/app/Plans/components/Step.tsx
+++ b/src/app/Plans/components/Step.tsx
@@ -26,7 +26,7 @@ const Step: React.FunctionComponent<IStepProps> = ({ type, error }: IStepProps) 
         className={spacing.mlSm}
         height="1em"
         width="1em"
-        color={successColor.value}
+        color={error ? dangerColor.value : successColor.value}
       />
     );
   }

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -38,7 +38,7 @@ import TableEmptyState from '@app/common/components/TableEmptyState';
 import { IVMStatus } from '@app/queries/types';
 import { usePlansQuery } from '@app/queries/plans';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
-import { formatTimestamp } from '@app/common/helpers';
+import { formatTimestamp, getStepType } from '@app/common/helpers';
 import {
   useProvidersQuery,
   findProvidersByRefs,
@@ -161,6 +161,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const rows: IRow[] = [];
 
   currentPageItems.forEach((vmStatus: IVMStatus) => {
+    const pipeline = vmStatus.pipeline.map((step, index) => getStepType(vmStatus, index));
     const isExpanded = isVMExpanded(vmStatus);
 
     const ratio = getTotalCopiedRatio(vmStatus);

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -160,11 +160,6 @@ const VMMigrationDetails: React.FunctionComponent = () => {
 
   const rows: IRow[] = [];
 
-  const getVMStatus = (vmStatus) => {
-    console.log('vmStatus:', vmStatus);
-    return vmStatus;
-  };
-
   currentPageItems.forEach((vmStatus: IVMStatus) => {
     const isExpanded = isVMExpanded(vmStatus);
 
@@ -179,7 +174,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         formatTimestamp(vmStatus.completed),
         `${Math.round(ratio.completed / 1024)} / ${Math.round(ratio.total / 1024)} GB`,
         {
-          title: <PipelineSummary status={getVMStatus(vmStatus)} />,
+          title: <PipelineSummary status={vmStatus} />,
         },
       ],
     });

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -161,9 +161,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const rows: IRow[] = [];
 
   currentPageItems.forEach((vmStatus: IVMStatus) => {
-    const pipeline = vmStatus.pipeline.map((step, index) => getStepType(vmStatus, index));
     const isExpanded = isVMExpanded(vmStatus);
-
     const ratio = getTotalCopiedRatio(vmStatus);
 
     rows.push({

--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 import { Flex, FlexItem, Text } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody, ICell, IRow, cellWidth } from '@patternfly/react-table';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  ICell,
+  IRow,
+  cellWidth,
+  truncate,
+} from '@patternfly/react-table';
 
 import Step from './Step';
 import { IVMStatus, IStep } from '@app/queries/types';
@@ -21,7 +29,7 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
       transforms: [cellWidth(40)],
     },
     { title: 'Elapsed time', transforms: [cellWidth(20)] },
-    { title: 'State' },
+    { title: 'State', cellTransforms: [truncate] },
   ];
 
   const rows: IRow[] = status.pipeline.map((step: IStep, index) => ({
@@ -46,7 +54,7 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
       {
         title: <TickingElapsedTime start={step.started} end={step.completed} />,
       },
-      step.phase,
+      step.error ? `${step.error?.phase}: ${step.error?.reasons}` : step.phase,
     ],
   }));
 

--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -6,7 +6,7 @@ import Step from './Step';
 import { IVMStatus, IStep } from '@app/queries/types';
 import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
 import { MigrationVMStepsType } from '@app/common/constants';
-import { getStepType } from '@app/common/helpers';
+import { getStepType, isStepOnError } from '@app/common/helpers';
 
 interface IVMStatusTableProps {
   status: IVMStatus;
@@ -35,7 +35,7 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
             flexWrap={{ default: 'nowrap' }}
           >
             <FlexItem>
-              <Step type={getStepType(status, index)} error={!!status.error?.phase} />
+              <Step type={getStepType(status, index)} error={isStepOnError(status, index)} />
             </FlexItem>
             <FlexItem>
               <Text>{MigrationVMStepsType[step.name] || step.name}</Text>

--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -54,7 +54,7 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
       {
         title: <TickingElapsedTime start={step.started} end={step.completed} />,
       },
-      step.error ? `${step.error?.phase}: ${step.error?.reasons}` : step.phase,
+      step.error ? `${step.phase}: ${step.error?.reasons}` : step.phase,
     ],
   }));
 

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -15,7 +15,7 @@ import {
 import { IVMStatus } from '@app/queries/types';
 import { MigrationVMStepsType } from '@app/common/constants';
 import './PipelineSummary.css';
-import { findCurrentStep } from '../helpers';
+import { findCurrentStep, isStepOnError } from '../helpers';
 
 interface IDashProps {
   isReached: boolean;
@@ -100,6 +100,7 @@ const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
   status,
 }: IPipelineSummaryProps) => {
   const title = getPipelineSummaryTitle(status);
+
   if (status.completed) {
     return (
       <Summary title={title}>
@@ -114,7 +115,7 @@ const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
         {currentStepIndex > 0 ? <Dash isReached={true} /> : null}
         <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
           <ResourcesAlmostFullIcon
-            color={status.error?.phase ? dangerColor.value : infoColor.value}
+            color={isStepOnError(status, currentStepIndex) ? dangerColor.value : infoColor.value}
           />
         </FlexItem>
         {currentStepIndex < status.pipeline.length - 1 ? (

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -13,9 +13,9 @@ import {
 } from '@patternfly/react-tokens';
 
 import { IVMStatus } from '@app/queries/types';
-import { MigrationVMStepsType } from '@app/common/constants';
+import { MigrationVMStepsType, StepType } from '@app/common/constants';
 import './PipelineSummary.css';
-import { findCurrentStep, isStepOnError } from '../helpers';
+import { findCurrentStep, getStepType, isStepOnError } from '../helpers';
 
 interface IDashProps {
   isReached: boolean;
@@ -28,53 +28,6 @@ const Dash: React.FunctionComponent<IDashProps> = ({ isReached }: IDashProps) =>
     </FlexItem>
   );
 };
-
-interface IChainProps {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  Face: React.ComponentClass<any>;
-  times: number;
-  color: {
-    name: string;
-    value: string;
-    var: string;
-  };
-}
-
-const Chain: React.FunctionComponent<IChainProps> = ({ Face, times, color }: IChainProps) => {
-  return times < 1 ? null : (
-    <>
-      <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-        <Face color={color.value} />
-      </FlexItem>
-      {times > 1 ? (
-        <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-          {color === disabledColor ? <Dash isReached={false} /> : <Dash isReached={true} />}
-        </FlexItem>
-      ) : null}
-      <Chain Face={Face} times={times - 1} color={color} />
-    </>
-  );
-};
-
-interface ISummaryProps {
-  title: string;
-  children: React.ReactNode;
-}
-
-const Summary: React.FunctionComponent<ISummaryProps> = ({ title, children }: ISummaryProps) => (
-  <Flex direction={{ default: 'column' }}>
-    <FlexItem>
-      <Text component="small">{title}</Text>
-      <Flex
-        spaceItems={{ default: 'spaceItemsNone' }}
-        alignContent={{ default: 'alignContentCenter' }}
-        flexWrap={{ default: 'nowrap' }}
-      >
-        {children}
-      </Flex>
-    </FlexItem>
-  </Flex>
-);
 
 export const getPipelineSummaryTitle = (status: IVMStatus): string => {
   const { currentStep } = findCurrentStep(status.pipeline);
@@ -92,55 +45,59 @@ export const getPipelineSummaryTitle = (status: IVMStatus): string => {
   return MigrationVMStepsType.NotStarted;
 };
 
+interface IGetStepTypeIcon {
+  status: IVMStatus;
+  index: number;
+}
+
+const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
+  status,
+  index,
+}: IGetStepTypeIcon) => {
+  const res = getStepType(status, index);
+  if (res === StepType.Full) {
+    return (
+      <>
+        <ResourcesFullIcon color={successColor.value} />
+        {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
+      </>
+    );
+  } else if (res === StepType.Half) {
+    return (
+      <>
+        <ResourcesAlmostFullIcon
+          color={isStepOnError(status, index) ? dangerColor.value : infoColor.value}
+        />
+        {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
+      </>
+    );
+  } else return <ResourcesAlmostEmptyIcon key={index} color={disabledColor.value} />;
+};
+
 interface IPipelineSummaryProps {
   status: IVMStatus;
 }
-
 const PipelineSummary: React.FunctionComponent<IPipelineSummaryProps> = ({
   status,
 }: IPipelineSummaryProps) => {
   const title = getPipelineSummaryTitle(status);
 
-  if (status.completed) {
-    return (
-      <Summary title={title}>
-        <Chain Face={ResourcesFullIcon} times={status.pipeline.length} color={successColor} />
-      </Summary>
-    );
-  } else if (status.started && !status.completed) {
-    const { currentStepIndex } = findCurrentStep(status.pipeline);
-    return (
-      <Summary title={title}>
-        <Chain Face={ResourcesFullIcon} times={currentStepIndex} color={successColor} />
-        {currentStepIndex > 0 ? <Dash isReached={true} /> : null}
-        <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
-          <ResourcesAlmostFullIcon
-            color={isStepOnError(status, currentStepIndex) ? dangerColor.value : infoColor.value}
-          />
-        </FlexItem>
-        {currentStepIndex < status.pipeline.length - 1 ? (
-          <>
-            <Dash isReached={false} />
-            <Chain
-              Face={ResourcesAlmostEmptyIcon}
-              times={status.pipeline.length - currentStepIndex - 1}
-              color={disabledColor}
-            />
-          </>
-        ) : null}
-      </Summary>
-    );
-  } else {
-    return (
-      <Summary title={title}>
-        <Chain
-          Face={ResourcesAlmostEmptyIcon}
-          times={status.pipeline.length}
-          color={disabledColor}
-        />
-      </Summary>
-    );
-  }
+  return (
+    <Flex direction={{ default: 'column' }}>
+      <FlexItem>
+        <Text component="small">{title}</Text>
+        <Flex
+          spaceItems={{ default: 'spaceItemsNone' }}
+          alignContent={{ default: 'alignContentCenter' }}
+          flexWrap={{ default: 'nowrap' }}
+        >
+          {status.pipeline.map((_, index) => (
+            <GetStepTypeIcon key={index} status={status} index={index} />
+          ))}
+        </Flex>
+      </FlexItem>
+    </Flex>
+  );
 };
 
 export default PipelineSummary;

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -58,7 +58,9 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   if (res === StepType.Full) {
     return (
       <>
-        <ResourcesFullIcon color={successColor.value} />
+        <ResourcesFullIcon
+          color={isStepOnError(status, index) ? dangerColor.value : successColor.value}
+        />
         {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
       </>
     );

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -55,6 +55,7 @@ export enum StepType {
   Half = 'Half',
   Empty = 'Empty',
 }
+
 export const PROVIDER_TYPE_NAMES = {
   [ProviderType.vsphere]: 'VMware',
   [ProviderType.openshift]: 'OpenShift Virtualization',

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -73,3 +73,9 @@ export const getStepType = (status: IVMStatus, index: number): StepType => {
     return StepType.Half;
   } else return StepType.Empty;
 };
+
+export const isStepOnError = (status: IVMStatus, index: number): boolean => {
+  const step = status.pipeline[index];
+  if (step.error) return true;
+  return false;
+};

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -158,6 +158,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         progress: { total: 3, completed: 1 },
         phase: 'Mock Step Phase',
         started: '2020-10-10T15:57:10Z',
+        error: {
+          phase: 'Error',
+          reasons: ['Something wrong happened.'],
+        },
       },
       {
         name: 'PostHook',


### PR DESCRIPTION
 VMStatusTable detailed step is `failed` when `pipeline.step` contains error, changed check.
Adds error structure to plans mock accordingly.
But more importantly refactor both Step and PipelineSummary to rely on `getStepType` in order for both to follow same path.