### PR TITLE
Add support for editing plans, and retain selections in later steps when changing values in earlier steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.9.0",
+    "@konveyor/lib-ui": "^1.10.5",
     "@patternfly/react-core": "^4.75.2",
     "@patternfly/react-icons": "^4.7.16",
     "@patternfly/react-styles": "^4.7.12",

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -137,16 +137,17 @@ export const getBuilderItemsWithMissingSources = (
   selectedVMs: IVMwareVM[],
   mappingType: MappingType
 ): IMappingBuilderItem[] => {
+  const nonEmptyItems = builderItems.filter((item) => item.source && item.target);
   const requiredSources = filterSourcesBySelectedVMs(
     mappingResourceQueries.availableSources,
     selectedVMs,
     mappingType
   );
   const missingSources = requiredSources.filter(
-    (source) => !builderItems.some((item) => item.source?.selfLink === source.selfLink)
+    (source) => !nonEmptyItems.some((item) => item.source?.selfLink === source.selfLink)
   );
   return [
-    ...builderItems,
+    ...nonEmptyItems,
     ...missingSources.map(
       (source): IMappingBuilderItem => ({
         source,

--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -17,22 +17,38 @@ import { getMappingSourceById, getMappingTargetByRef } from '../helpers';
 import { CLUSTER_API_VERSION, VIRT_META } from '@app/common/constants';
 import { nameAndNamespace } from '@app/queries/helpers';
 
+export const getBuilderItemsFromMappingItems = (
+  items: MappingItem[] | null,
+  mappingType: MappingType,
+  allSources: MappingSource[],
+  allTargets: MappingTarget[]
+): IMappingBuilderItem[] =>
+  items
+    ? (items
+        .map((item: MappingItem): IMappingBuilderItem | null => {
+          const source = getMappingSourceById(allSources, item.source.id);
+          const target = getMappingTargetByRef(allTargets, item.destination, mappingType);
+          if (source) {
+            return { source, target, highlight: false };
+          }
+          return null;
+        })
+        .filter((builderItem) => !!builderItem) as IMappingBuilderItem[])
+    : [];
+
 export const getBuilderItemsFromMapping = (
   mapping: Mapping,
   mappingType: MappingType,
   allSources: MappingSource[],
   allTargets: MappingTarget[]
 ): IMappingBuilderItem[] =>
-  (mapping.spec.map as MappingItem[])
-    .map((item: MappingItem): IMappingBuilderItem | null => {
-      const source = getMappingSourceById(allSources, item.source.id);
-      const target = getMappingTargetByRef(allTargets, item.destination, mappingType);
-      if (source) {
-        return { source, target, highlight: false };
-      }
-      return null;
-    })
-    .filter((builderItem) => !!builderItem) as IMappingBuilderItem[];
+  getBuilderItemsFromMappingItems(
+    mapping.spec.map as MappingItem[],
+    mappingType,
+    allSources,
+    allTargets
+  );
+
 interface IGetMappingParams {
   mappingType: MappingType;
   mappingName: string;

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
 
 import { IPlan } from '@app/queries/types';
 import { PlanStatusAPIType } from '@app/common/constants';
@@ -17,6 +18,7 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
   const [deletePlan, deletePlanResult] = useDeletePlanMutation(toggleDeleteModal);
+  const history = useHistory();
 
   const conditions = plan.status?.conditions || [];
 
@@ -29,14 +31,10 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
         isPlain
         dropdownItems={[
           <DropdownItem
-            isDisabled={
-              hasCondition(conditions, PlanStatusAPIType.Executing) ||
-              hasCondition(conditions, PlanStatusAPIType.Succeeded) ||
-              hasCondition(conditions, PlanStatusAPIType.Failed)
-            }
+            isDisabled={!!plan.status?.migration?.started}
             onClick={() => {
               setKebabIsOpen(false);
-              alert('TODO');
+              history.push(`/plans/${plan.metadata.name}/edit`);
             }}
             key="Edit"
           >

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -41,6 +41,7 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   React.useEffect(() => {
     // Clear selection when the tree type tab changes
     if (!isFirstRender.current) {
+      // TODO if editing, instead prefill the tree based on the first matching tree node for each selected VM?
       treeSelection.selectAll(false);
     }
     isFirstRender.current = false;

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -10,9 +10,15 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useSelectionState } from '@konveyor/lib-ui';
-import { useVMwareTreeQuery } from '@app/queries';
-import { IVMwareProvider, VMwareTree, VMwareTreeType } from '@app/queries/types';
-import { filterAndConvertVMwareTree, findVMTreePath, flattenVMwareTreeNodes } from './helpers';
+import { useVMwareTreeQuery, useVMwareVMsQuery } from '@app/queries';
+import { IPlan, IVMwareProvider, VMwareTree, VMwareTreeType } from '@app/queries/types';
+import {
+  filterAndConvertVMwareTree,
+  findMatchingNodeAndDescendants,
+  findNodesMatchingSelectedVMs,
+  flattenVMwareTreeNodes,
+  getSelectedVMsFromPlan,
+} from './helpers';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { PlanWizardFormState } from './PlanWizard';
 
@@ -21,14 +27,17 @@ import './FilterVMsForm.css';
 interface IFilterVMsFormProps {
   form: PlanWizardFormState['filterVMs'];
   sourceProvider: IVMwareProvider | null;
+  planBeingEdited: IPlan | null;
 }
 
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   form,
   sourceProvider,
+  planBeingEdited,
 }: IFilterVMsFormProps) => {
   const [searchText, setSearchText] = React.useState('');
 
+  const vmsQuery = useVMwareVMsQuery(sourceProvider);
   const treeQuery = useVMwareTreeQuery(sourceProvider, form.values.treeType);
 
   const treeSelection = useSelectionState({
@@ -38,15 +47,30 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   });
 
   const isFirstRender = React.useRef(true);
+  const lastTreeType = React.useRef(form.values.treeType);
   React.useEffect(() => {
-    // Clear selection when the tree type tab changes
-    if (!isFirstRender.current) {
-      // TODO if editing, instead prefill the tree based on the first matching tree node for each selected VM?
-      treeSelection.selectAll(false);
+    // Clear or reset selection when the tree type tab changes
+    const treeTypeChanged = form.values.treeType !== lastTreeType.current;
+    if (!isFirstRender.current && treeTypeChanged) {
+      if (!planBeingEdited || !form.values.isPrefilled) {
+        treeSelection.selectAll(false);
+        lastTreeType.current = form.values.treeType;
+      } else if (vmsQuery.isSuccess && treeQuery.isSuccess) {
+        const selectedVMs = getSelectedVMsFromPlan(planBeingEdited, vmsQuery);
+        const selectedTreeNodes = findNodesMatchingSelectedVMs(treeQuery.data || null, selectedVMs);
+        treeSelection.setSelectedItems(selectedTreeNodes);
+        lastTreeType.current = form.values.treeType;
+      }
     }
     isFirstRender.current = false;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.values.treeType]);
+  }, [
+    form.values.treeType,
+    form.values.isPrefilled,
+    planBeingEdited,
+    treeQuery,
+    vmsQuery,
+    treeSelection,
+  ]);
 
   return (
     <div className="plan-wizard-filter-vms-form">
@@ -69,8 +93,10 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
           title={<TabTitleText>By folders</TabTitleText>}
         />
       </Tabs>
-      {treeQuery.isLoading ? (
+      {vmsQuery.isLoading || treeQuery.isLoading ? (
         <LoadingEmptyState />
+      ) : vmsQuery.isError ? (
+        <Alert variant="danger" isInline title="Error loading VMs" />
       ) : treeQuery.isError ? (
         <Alert variant="danger" isInline title="Error loading VMware tree data" />
       ) : (
@@ -88,23 +114,14 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
             if (treeViewItem.id === 'converted-root') {
               treeSelection.selectAll(!treeSelection.areAllSelected);
             } else {
-              const matchingPath =
-                treeQuery.data && findVMTreePath(treeQuery.data, treeViewItem.id || '');
-              const matchingNode = matchingPath && matchingPath[matchingPath.length - 1];
-              if (matchingNode) {
-                const nodesToSelect: VMwareTree[] = [];
-                const pushNodeAndDescendants = (n: VMwareTree) => {
-                  nodesToSelect.push(n);
-                  if (n.children) {
-                    n.children.forEach(pushNodeAndDescendants);
-                  }
-                };
-                pushNodeAndDescendants(matchingNode);
-                treeSelection.selectMultiple(
-                  nodesToSelect,
-                  !treeSelection.isItemSelected(matchingNode)
-                );
-              }
+              const nodesToSelect = findMatchingNodeAndDescendants(
+                treeQuery.data || null,
+                treeViewItem.id || ''
+              );
+              treeSelection.selectMultiple(
+                nodesToSelect,
+                !treeSelection.isItemSelected(nodesToSelect[0])
+              );
             }
           }}
           searchProps={{

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -4,7 +4,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import { IOpenShiftProvider, IVMwareProvider } from '@app/queries/types';
+import { IOpenShiftProvider, IPlan, IVMwareProvider } from '@app/queries/types';
 import { useProvidersQuery } from '@app/queries';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { PlanWizardFormState } from './PlanWizard';
@@ -12,9 +12,13 @@ import { useNamespacesQuery } from '@app/queries/namespaces';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
+  planBeingEdited: IPlan | null;
 }
 
-const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGeneralFormProps) => {
+const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
+  form,
+  planBeingEdited,
+}: IGeneralFormProps) => {
   const providersQuery = useProvidersQuery();
   const vmwareProviders = providersQuery.data?.vsphere || [];
   const openshiftProviders = providersQuery.data?.openshift || [];
@@ -48,6 +52,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({ form }: IGene
         label="Plan name"
         isRequired
         fieldId="plan-name"
+        inputProps={{ isDisabled: !!planBeingEdited }}
       />
       <ValidatedTextInput
         component={TextArea}

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -51,6 +51,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
   mappingType,
   selectedVMs,
 }: IMappingFormProps) => {
+  // TODO maybe move this query to the wizard level (separate for network/storage), use for prefilling based on mappingBeingEdited
   const mappingResourceQueries = useMappingResourceQueries(
     sourceProvider,
     targetProvider,

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -38,6 +38,7 @@ import {
 import { isSameResource } from '@app/queries/helpers';
 
 import './MappingForm.css';
+import { QueryStatus } from 'react-query';
 
 interface IMappingFormProps {
   form: PlanWizardFormState['storageMapping'] | PlanWizardFormState['networkMapping'];
@@ -61,6 +62,30 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
     targetProvider,
     mappingType
   );
+
+  const hasInitialized = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasInitialized.current && mappingResourceQueries.status === QueryStatus.Success) {
+      hasInitialized.current = true;
+      if (form.values.builderItems.length > 0) {
+        form.fields.builderItems.setValue(
+          getBuilderItemsWithMissingSources(
+            form.values.builderItems,
+            mappingResourceQueries,
+            selectedVMs,
+            mappingType
+          )
+        );
+      }
+    }
+  }, [
+    form.fields.builderItems,
+    form.values.builderItems,
+    mappingResourceQueries,
+    mappingType,
+    selectedVMs,
+  ]);
+
   const mappingsQuery = useMappingsQuery(mappingType);
 
   const filteredMappings = (mappingsQuery.data?.items || []).filter(

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -25,6 +25,7 @@ import {
   IVMwareProvider,
   IOpenShiftProvider,
   IVMwareVM,
+  IPlan,
 } from '@app/queries/types';
 import { MappingBuilder, IMappingBuilderItem } from '@app/Mappings/components/MappingBuilder';
 import { useMappingResourceQueries, useMappingsQuery } from '@app/queries';
@@ -44,6 +45,7 @@ interface IMappingFormProps {
   targetProvider: IOpenShiftProvider | null;
   mappingType: MappingType;
   selectedVMs: IVMwareVM[];
+  planBeingEdited: IPlan | null;
 }
 
 const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
@@ -52,6 +54,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
   targetProvider,
   mappingType,
   selectedVMs,
+  planBeingEdited,
 }: IMappingFormProps) => {
   const mappingResourceQueries = useMappingResourceQueries(
     sourceProvider,
@@ -101,6 +104,11 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
 
   const hasAddedItems = form.values.selectedExistingMapping
     ? form.values.selectedExistingMapping.spec.map.length < form.values.builderItems.length
+    : planBeingEdited
+    ? (mappingType === MappingType.Network
+        ? planBeingEdited.spec.map.networks
+        : planBeingEdited.spec.map.datastores
+      ).length < form.values.builderItems.length
     : false;
 
   if (mappingResourceQueries.isLoading || mappingsQuery.isLoading) {
@@ -115,12 +123,14 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
 
   return (
     <Form>
-      <TextContent>
-        <Text component="p">
-          Start with an existing {mappingType.toLowerCase()} mapping between your source and target
-          providers, or create a new one.
-        </Text>
-      </TextContent>
+      {!form.values.isPrefilled ? (
+        <TextContent>
+          <Text component="p">
+            Start with an existing {mappingType.toLowerCase()} mapping between your source and
+            target providers, or create a new one.
+          </Text>
+        </TextContent>
+      ) : null}
       <Flex direction={{ default: 'column' }} className={spacing.mbMd}>
         {!form.values.isPrefilled ? (
           <FlexItem>

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -275,6 +275,7 @@ const PlanWizard: React.FunctionComponent = () => {
             targetProvider={forms.general.values.targetProvider}
             mappingType={MappingType.Network}
             selectedVMs={forms.selectVMs.values.selectedVMs}
+            planBeingEdited={planBeingEdited}
           />
         </WizardStepContainer>
       ),
@@ -293,6 +294,7 @@ const PlanWizard: React.FunctionComponent = () => {
             targetProvider={forms.general.values.targetProvider}
             mappingType={MappingType.Storage}
             selectedVMs={forms.selectVMs.values.selectedVMs}
+            planBeingEdited={planBeingEdited}
           />
         </WizardStepContainer>
       ),

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -196,14 +196,14 @@ const PlanWizard: React.FunctionComponent = () => {
       id: StepId.General,
       name: 'General',
       component: (
-        <WizardStepContainer title="General Settings">
+        <WizardStepContainer title="General settings">
           <GeneralForm form={forms.general} />
         </WizardStepContainer>
       ),
       enableNext: forms.general.isValid,
     },
     {
-      name: 'VM Selection',
+      name: 'VM selection',
       steps: [
         {
           id: StepId.FilterVMs,
@@ -238,9 +238,9 @@ const PlanWizard: React.FunctionComponent = () => {
     },
     {
       id: StepId.NetworkMapping,
-      name: 'Network Mapping',
+      name: 'Network mapping',
       component: (
-        <WizardStepContainer title="Network Mapping">
+        <WizardStepContainer title="Network mapping">
           <MappingForm
             key="mapping-form-network"
             form={forms.networkMapping}
@@ -256,9 +256,9 @@ const PlanWizard: React.FunctionComponent = () => {
     },
     {
       id: StepId.StorageMapping,
-      name: 'Storage Mapping',
+      name: 'Storage mapping',
       component: (
-        <WizardStepContainer title="Map Storage">
+        <WizardStepContainer title="Storage mapping">
           <MappingForm
             key="mapping-form-storage"
             form={forms.storageMapping}

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -222,7 +222,7 @@ const PlanWizard: React.FunctionComponent = () => {
       name: 'General',
       component: (
         <WizardStepContainer title="General settings">
-          <GeneralForm form={forms.general} />
+          <GeneralForm form={forms.general} planBeingEdited={planBeingEdited} />
         </WizardStepContainer>
       ),
       enableNext: forms.general.isValid,

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -153,31 +153,23 @@ const PlanWizard: React.FunctionComponent = () => {
 
   /* eslint-disable react-hooks/exhaustive-deps */
 
-  // When providers change, reset dependent forms (filter selections)
+  // When providers change, reset dependent forms
   React.useEffect(() => {
     if (!isFirstRender.current && isDonePrefilling) {
       forms.filterVMs.reset();
-      console.log('RESETTING from change?');
+      forms.networkMapping.reset();
+      forms.storageMapping.reset();
     }
     isFirstRender.current = false;
   }, [forms.general.values.sourceProvider, forms.general.values.targetProvider]);
 
-  // When filter selections change, reset dependent forms (VM selections)
+  // When filter selections change, reset dependent forms
   React.useEffect(() => {
     if (!isFirstRender.current && isDonePrefilling) {
       forms.selectVMs.reset();
     }
     isFirstRender.current = false;
   }, [forms.filterVMs.values.selectedTreeNodes]);
-
-  // When VM selections change, reset dependent forms (mappings)
-  React.useEffect(() => {
-    if (!isFirstRender.current && isDonePrefilling) {
-      forms.networkMapping.reset();
-      forms.storageMapping.reset();
-    }
-    isFirstRender.current = false;
-  }, [forms.selectVMs.values.selectedVMs]);
 
   /* eslint-enable react-hooks/exhaustive-deps */
 

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -127,7 +127,11 @@ const PlanWizard: React.FunctionComponent = () => {
     planBeingEdited
   );
 
-  const { prefillQueryStatus, prefillQueryError } = useEditingPrefillEffect(forms, planBeingEdited);
+  const { prefillQueryStatus, prefillQueryError, isDonePrefilling } = useEditingPrefillEffect(
+    forms,
+    planBeingEdited,
+    !!editRouteMatch
+  );
 
   enum StepId {
     General = 1,
@@ -151,15 +155,16 @@ const PlanWizard: React.FunctionComponent = () => {
 
   // When providers change, reset dependent forms (filter selections)
   React.useEffect(() => {
-    if (!isFirstRender.current) {
+    if (!isFirstRender.current && isDonePrefilling) {
       forms.filterVMs.reset();
+      console.log('RESETTING from change?');
     }
     isFirstRender.current = false;
   }, [forms.general.values.sourceProvider, forms.general.values.targetProvider]);
 
   // When filter selections change, reset dependent forms (VM selections)
   React.useEffect(() => {
-    if (!isFirstRender.current) {
+    if (!isFirstRender.current && isDonePrefilling) {
       forms.selectVMs.reset();
     }
     isFirstRender.current = false;
@@ -167,7 +172,7 @@ const PlanWizard: React.FunctionComponent = () => {
 
   // When VM selections change, reset dependent forms (mappings)
   React.useEffect(() => {
-    if (!isFirstRender.current) {
+    if (!isFirstRender.current && isDonePrefilling) {
       forms.networkMapping.reset();
       forms.storageMapping.reset();
     }
@@ -317,7 +322,8 @@ const PlanWizard: React.FunctionComponent = () => {
     plansQuery.isLoading ||
     networkMappingsQuery.isLoading ||
     storageMappingsQuery.isLoading ||
-    prefillQueryStatus === QueryStatus.Loading
+    prefillQueryStatus === QueryStatus.Loading ||
+    !isDonePrefilling
   ) {
     return <LoadingEmptyState />;
   }

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -156,27 +156,17 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const isFirstRender = React.useRef(true);
 
-  /* eslint-disable react-hooks/exhaustive-deps */
-
-  // When providers change, reset dependent forms
+  // When providers change, reset all other forms
   React.useEffect(() => {
     if (!isFirstRender.current && isDonePrefilling) {
       forms.filterVMs.reset();
+      forms.selectVMs.reset();
       forms.networkMapping.reset();
       forms.storageMapping.reset();
     }
     isFirstRender.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [forms.general.values.sourceProvider, forms.general.values.targetProvider]);
-
-  // When filter selections change, reset dependent forms
-  React.useEffect(() => {
-    if (!isFirstRender.current && isDonePrefilling) {
-      forms.selectVMs.reset();
-    }
-    isFirstRender.current = false;
-  }, [forms.filterVMs.values.selectedTreeNodes]);
-
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   const onClose = () => history.push('/plans');
 

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -12,15 +12,19 @@ import { generateMappings } from './helpers';
 interface IReviewProps {
   forms: PlanWizardFormState;
   createPlanResult: MutationResult<IKubeResponse<IPlan>, KubeClientError>;
+  patchPlanResult: MutationResult<IKubeResponse<IPlan>, KubeClientError>;
   createNetworkMappingResult: MutationResult<IKubeResponse<Mapping>, KubeClientError>;
   createStorageMappingResult: MutationResult<IKubeResponse<Mapping>, KubeClientError>;
+  planBeingEdited: IPlan | null;
 }
 
 const Review: React.FunctionComponent<IReviewProps> = ({
   forms,
   createPlanResult,
+  patchPlanResult,
   createNetworkMappingResult,
   createStorageMappingResult,
+  planBeingEdited,
 }: IReviewProps) => {
   // Reset mutation state on unmount (going back in the wizard clears errors)
   React.useEffect(() => {
@@ -36,8 +40,8 @@ const Review: React.FunctionComponent<IReviewProps> = ({
     <Form>
       <TextContent>
         <Text component="p">
-          Review the information below and click Finish to create your migration plan. Use the Back
-          button to make changes.
+          Review the information below and click Finish to {!planBeingEdited ? 'create' : 'save'}{' '}
+          your migration plan. Use the Back button to make changes.
         </Text>
       </TextContent>
       <Grid hasGutter className={`${spacing.mtSm} ${spacing.mbMd}`}>
@@ -64,9 +68,13 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={9}>{forms.selectVMs.values.selectedVMs.length}</GridItem>
       </Grid>
       <MutationStatus
-        results={[createPlanResult, createNetworkMappingResult, createStorageMappingResult]}
+        results={[
+          !planBeingEdited ? createPlanResult : patchPlanResult,
+          createNetworkMappingResult,
+          createStorageMappingResult,
+        ]}
         errorTitles={[
-          'Error creating migration plan',
+          `Error ${!planBeingEdited ? 'creating' : 'patching'} migration plan`,
           'Error creating network mapping',
           'Error creating storage mapping',
         ]}

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  Pagination,
-  TextContent,
-  Text,
-  Alert,
-  Level,
-  LevelItem,
-  Flex,
-} from '@patternfly/react-core';
+import { Pagination, TextContent, Text, Alert, Level, LevelItem } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   Table,

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -61,15 +61,23 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   const treeQueriesStatus = getAggregateQueryStatus([hostTreeQuery, vmTreeQuery]);
   const vmsQuery = useVMwareVMsQuery(sourceProvider);
 
+  // Even if some of the already-selected VMs don't match the filter, include them in the list.
+  const selectedVMsOnMount = React.useRef(form.values.selectedVMs);
   const { availableVMs, treePathInfoByVM } = React.useMemo(() => {
-    const availableVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || []);
+    const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || []);
+    const availableVMs = [
+      ...selectedVMsOnMount.current,
+      ...filteredVMs.filter(
+        (vm) => !selectedVMsOnMount.current.some((selectedVM) => vm.id === selectedVM.id)
+      ),
+    ];
     const treePathInfoByVM = getVMTreePathInfoByVM(
       availableVMs,
       hostTreeQuery.data || null,
       vmTreeQuery.data || null
     );
     return { availableVMs, treePathInfoByVM };
-  }, [selectedTreeNodes, hostTreeQuery.data, vmTreeQuery.data, vmsQuery.data]);
+  }, [selectedTreeNodes, vmsQuery.data, hostTreeQuery.data, vmTreeQuery.data]);
 
   const filterCategories: FilterCategory<IVMwareVM>[] = [
     {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -213,7 +213,6 @@ export const findMatchingNodeAndDescendants = (
     ?.slice()
     .reverse()
     .find((node) => node.kind !== 'VM');
-  console.log({ vmSelfLink, matchingNode });
   if (!matchingNode) return [];
   const nodeAndDescendants: VMwareTree[] = [];
   const pushNodeAndDescendants = (n: VMwareTree) => {

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -90,8 +90,7 @@ export const getAggregateQueryStatus = (
   if (queryResults.some((result) => result.isError)) return QueryStatus.Error;
   if (queryResults.some((result) => result.isLoading)) return QueryStatus.Loading;
   if (queryResults.every((result) => result.isIdle)) return QueryStatus.Idle;
-  if (queryResults.every((result) => result.isSuccess)) return QueryStatus.Success;
-  return QueryStatus.Error; // Should never reach this, just makes TS happy
+  return QueryStatus.Success;
 };
 
 export const getFirstQueryError = <TError>(

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -94,13 +94,14 @@ export const useDeleteMappingMutation = (
   );
 };
 
-interface IMappingResourcesResult {
+export interface IMappingResourcesResult {
   availableSources: MappingSource[];
   availableTargets: MappingTarget[];
   isLoading: boolean;
   isError: boolean;
   status: QueryStatus;
   error: unknown; // TODO not sure how to handle error types yet
+  queries: QueryResult<unknown>[];
 }
 
 export const useMappingResourceQueries = (
@@ -148,6 +149,7 @@ export const useMappingResourceQueries = (
     isError: status === QueryStatus.Error,
     status,
     error,
+    queries: queriesToWatch,
   };
 };
 

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -52,6 +52,25 @@ export const useCreatePlanMutation = (
   );
 };
 
+export const usePatchPlanMutation = (
+  existingPlanName: string,
+  onSuccess?: () => void
+): MutationResultPair<IKubeResponse<IPlan>, KubeClientError, IPlan, unknown> => {
+  const client = useAuthorizedK8sClient();
+  const queryCache = useQueryCache();
+  const { pollFasterAfterMutation } = usePollingContext();
+  return useMockableMutation<IKubeResponse<IPlan>, KubeClientError, IPlan>(
+    (plan: IPlan) => client.patch(planResource, existingPlanName, plan),
+    {
+      onSuccess: () => {
+        queryCache.invalidateQueries('plans');
+        pollFasterAfterMutation();
+        onSuccess && onSuccess();
+      },
+    }
+  );
+};
+
 export const useDeletePlanMutation = (
   onSuccess?: () => void
 ): MutationResultPair<IKubeResponse<IKubeStatus>, KubeClientError, IPlan, unknown> => {

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -68,8 +68,12 @@ export const useDeletePlanMutation = (
   );
 };
 
-export const getPlanNameSchema = (plansQuery: QueryResult<IKubeList<IPlan>>): yup.StringSchema =>
+export const getPlanNameSchema = (
+  plansQuery: QueryResult<IKubeList<IPlan>>,
+  planBeingEdited: IPlan | null
+): yup.StringSchema =>
   dnsLabelNameSchema.test('unique-name', 'A plan with this name already exists', (value) => {
+    if (planBeingEdited?.metadata.name === value) return true;
     if (plansQuery.data?.items.find((plan) => plan.metadata.name === value)) return false;
     return true;
   });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -99,6 +99,13 @@ export const routes: AppRouteConfig[] = [
     isProtected: true,
   },
   {
+    component: PlanWizard,
+    exact: false,
+    path: '/plans/:planName/edit',
+    title: `${APP_TITLE} | Create Migration Plan`,
+    isProtected: true,
+  },
+  {
     component: VMMigrationDetails,
     exact: false,
     path: '/plans/:planName',

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,10 +546,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@konveyor/lib-ui@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-1.9.0.tgz#6335f6c9607c5d0c67f328feba28e1816a79c8d8"
-  integrity sha512-SbEAM7KAkWWksPxicQJ8qxyoklGjgIeXk7iK5Y6bN2Vx0aH8ZpQ5JzBS15PPck2PYes/oPGlbbi2L50HT5xeSw==
+"@konveyor/lib-ui@^1.10.5":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/@konveyor/lib-ui/-/lib-ui-1.10.5.tgz#8e180ec770fdde7b9e07eb4e8127cd9904b5fe39"
+  integrity sha512-iAKeroSJdFR3SSGReEjYl3wgUkUCP/lE+0VKEv91SYzTy7Dz7KgRcOF/lqapsJFxBqEQIclXqNsxzo23QUh0Cg==
   dependencies:
     fast-deep-equal "^3.1.3"
     yup "^0.29.3"


### PR DESCRIPTION
Resolves #104.

* Adds a route `/plans/:planName/edit` which renders the PlanWizard in addition to `/plans/create`.
* Adds a route match to PlanWizard to determine if it is rendered by the `/edit` route, and if so, grabs the `planBeingEdited`.
* Adds a hook `useEditingPrefillEffect` which will wait for queries to finish and then pre-fill the forms with values based on the `planBeingEdited`.
  * Because this happens asynchronously, the wizard was acting as if the user changed the form values that are being prefilled, so the effects which reset forms on dependent value changes will only run after prefilling is complete.
  * Because the prefilling hook requires some queries not otherwise required by the plan wizard, it keeps track of its aggregate query status and returns that to the wizard so it can continue to render a loading spinner until the prefilling is done.
  * The `window.setTimeout(() => { setIsDonePrefilling(true); }, 0);` is strange; without it, React will batch all the field changes and the `isDonePrefilling` change into one render, which means [this effect](https://github.com/konveyor/virt-ui/pull/189/files#diff-55b411ad333b40962073e7eb43e4f9db265aaada61377172a4e4b5e98384ec07R160) will run anyway even though we want it to *not* run during prefilling and then run if values change after prefilling. The `setTimeout` just makes the `setIsDonePrefilling` asynchronous: the function will return and allow React to batch all the new field values into a render before it handles the new `isDonePrefilling` value in the next render.
* Cleans up some text stuff in the wizard
* Adds a new `isPrefilled` field to the mapping forms and the filterVMs form, which is not visible to the user but is set to true initially if the wizard is opened for editing.
  * If a form is reset (because the user changed providers), `isPrefilled` will go back to false, so that form will behave as if it wasn't in editing mode (e.g. the dropdown for existing mappings comes back). Essentially, changing the providers on the general step means the entire plan needs to be replaced, so it mostly behaves the same as in create mode after that.
* When the wizard is in editing mode (and a step still has `isPrefilled` set to true), some things are rendered differently:
  * "Create" text is replaced with "Edit" / "Save" where appropriate
  * On the mapping steps, the dropdown to select an existing mapping is hidden.
  * On the filter VMs step, initially and when switching the tree type tabs, instead of clearing the selections, they are reset based on the planBeingEdited (the first tree item matching each selected VM is selected). That way, the filters start out in a state which will include the already-selected VMs when moving on to the next step.
* Prevents the user from changing the plan name when editing (limitation of patching CRs).
* Adds a mutation for patching the plan CR, and wires it up when submitting the wizard.
* Factors out a lot of initialization logic into helpers since it is reused for prefilling (e.g. finding missing mapping sources)

Some changes have been made that also affect creating new plans:
* When "Filter VMs" tree selections change, the subsequent forms (Select VMs and Mappings) are no longer cleared / reset. Similarly, when the "Select VMs" selections change, the Mappings forms are no longer cleared / reset. Instead, these steps can now retain their original values while adapting to the new context.
  * If the tree selections result in a list of VMs that does not include the already-selected VMs, those VMs will be included anyway at the top of the table. That way you can still see your entire selection regardless of the tree filters. This also means that you can select something in the tree, click Next, select some VMs, go back, select something different in the tree, click Next, and select some more VMs (use multiple passes of filtering when building your list of VMs). This is a corner case for sure, but it prevents the annoying result of having your list of VMs lost if you decided to change the filters at all.
  * If the selected VMs change, the set of required mapping sources could change with it. The mapping forms will now check to see if their current selections are missing any new required sources on mount, and add them. If any previously-required sources are no longer required and the user hadn't selected a target for them, they are removed. However, no mapping items with selected targets will be removed.
  * With these changes, the only thing that will clear selections in the wizard is changing providers. Everything else is malleable, you can hop backward and forward around the wizard changing whatever you like, and the other steps will adapt logically.