### PR TITLE
When editing a plan, keep only required mapping sources when VMs change

### DIFF
--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -135,7 +135,8 @@ export const getBuilderItemsWithMissingSources = (
   builderItems: IMappingBuilderItem[],
   mappingResourceQueries: IMappingResourcesResult,
   selectedVMs: IVMwareVM[],
-  mappingType: MappingType
+  mappingType: MappingType,
+  keepNonRequiredSources: boolean
 ): IMappingBuilderItem[] => {
   const nonEmptyItems = builderItems.filter((item) => item.source && item.target);
   const requiredSources = filterSourcesBySelectedVMs(
@@ -143,11 +144,16 @@ export const getBuilderItemsWithMissingSources = (
     selectedVMs,
     mappingType
   );
+  const itemsToKeep = keepNonRequiredSources
+    ? nonEmptyItems
+    : nonEmptyItems.filter((item) =>
+        requiredSources.some((source) => item.source?.selfLink === source.selfLink)
+      );
   const missingSources = requiredSources.filter(
-    (source) => !nonEmptyItems.some((item) => item.source?.selfLink === source.selfLink)
+    (source) => !itemsToKeep.some((item) => item.source?.selfLink === source.selfLink)
   );
   return [
-    ...nonEmptyItems,
+    ...itemsToKeep,
     ...missingSources.map(
       (source): IMappingBuilderItem => ({
         source,

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -73,7 +73,8 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
             form.values.builderItems,
             mappingResourceQueries,
             selectedVMs,
-            mappingType
+            mappingType,
+            !!form.values.selectedExistingMapping
           )
         );
       }
@@ -81,6 +82,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
   }, [
     form.fields.builderItems,
     form.values.builderItems,
+    form.values.selectedExistingMapping,
     mappingResourceQueries,
     mappingType,
     selectedVMs,
@@ -121,7 +123,8 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
         newBuilderItems,
         mappingResourceQueries,
         selectedVMs,
-        mappingType
+        mappingType,
+        true
       )
     );
     form.fields.isSaveNewMapping.setValue(false);

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -414,7 +414,8 @@ export const useEditingPrefillEffect = (
           ),
           networkMappingResourceQueries,
           selectedVMs,
-          MappingType.Network
+          MappingType.Network,
+          false
         )
       );
       forms.networkMapping.fields.builderItems.setIsTouched(true);
@@ -430,7 +431,8 @@ export const useEditingPrefillEffect = (
           ),
           storageMappingResourceQueries,
           selectedVMs,
-          MappingType.Storage
+          MappingType.Storage,
+          false
         )
       );
       forms.storageMapping.fields.builderItems.setIsTouched(true);


### PR DESCRIPTION
Based on a discussion with @vconzola 

Previously, the mapping steps of the wizard kept all mapping items with selected targets no matter what changed. So you could have this scenario:

* User selects VMs A and B, which require mapping sources 1 and 2, and clicks Next
* User selects targets for both sources
* User goes back, deselects VM B, now only source 1 is required.
* When they proceed again, both sources still appear even though the second one is now irrelevant.

Now, this will not happen (source 2 will disappear, just as it would if the user hadn't selected a target for it). This behavior is true only when creating a new mapping from scratch or editing the one prefilled from a plan (if you select an existing mapping when making a new plan, the entire mapping will still be shown even if some of its sources are irrelevant, to prevent confusion).