### PR TITLE
Inventory payload request to use namespace

### DIFF
--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -64,7 +64,7 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
   });
 
   const inventoryDownloadURL = `/inventory-payload-api/api/v1/extract?providers=${selectedItems
-    .map((provider) => provider.name)
+    .map((provider) => `${VIRT_META.namespace}/${provider.name}`)
     .join()}`;
 
   const columns: ICell[] = [

--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -64,7 +64,7 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
   });
 
   const inventoryDownloadURL = `/inventory-payload-api/api/v1/extract?providers=${selectedItems
-    .map((provider) => `${VIRT_META.namespace}/${provider.name}`)
+    .map((provider) => `${provider.namespace}/${provider.name}`)
     .join()}`;
 
   const columns: ICell[] = [


### PR DESCRIPTION
The API call to the inventory-payload app has [changed](
https://github.com/konveyor/virt-payload/commit/785efd77c558961c4fbedc301a320eb9afd0dd34) slightly from:
`/api/v1/extract?providers=provider1,provider2`
to:
`/api/v1/extract?providers=namespace1/provider1,namespace2/provider2`

