### PR TITLE
Ignore self-signed certs in remote dev mode

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -3,6 +3,7 @@ _dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $_dir/..
 export NODE_ENV=development
 export EXPRESS_PORT=9001
+export NODE_TLS_REJECT_UNAUTHORIZED="0"
 yarn concurrently --names "EXPRESS,WEBPACK" -c "green.bold.inverse,blue.bold.inverse" \
   "$_dir/run-local-express.sh --auto-reload" \
   "./node_modules/webpack-dev-server/bin/webpack-dev-server.js \


### PR DESCRIPTION
In remote dev mode, we still need to ignore self-signed certs in order to allow the redirect to the login page.