### PR TITLE
Always use virtMeta.json for proxy URLs

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -72,16 +72,16 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
 }
 
 let clusterApiProxyOptions = {
-  target: 'https://api.openshift-apiserver.svc.cluster.local',
+  target: virtMeta.clusterApi,
   changeOrigin: true,
   pathRewrite: {
     '^/cluster-api/': '/',
   },
-  secure: false,
+  secure: true,
 };
 
 let inventoryApiProxyOptions = {
-  target: 'http://inventory.openshift-migration.svc.cluster.local',
+  target: virtMeta.inventoryApi,
   changeOrigin: true,
   pathRewrite: {
     '^/inventory-api/': '/',
@@ -90,7 +90,7 @@ let inventoryApiProxyOptions = {
 };
 
 let inventoryPayloadApiProxyOptions = {
-  target: 'http://inventory-payload.openshift-migration.svc.cluster.local:8080',
+  target: virtMeta.inventoryPayloadApi,
   changeOrigin: true,
   pathRewrite: {
     '^/inventory-payload-api/': '/',
@@ -98,22 +98,20 @@ let inventoryPayloadApiProxyOptions = {
   secure: false,
 };
 
-if (process.env['NODE_ENV'] === 'development') {
+// Enable debug log level when in development or when DEBUG env variable is '*'
+if (process.env['NODE_ENV'] === 'development' || process.env['DEBUG'] === '*') {
   clusterApiProxyOptions = {
     ...clusterApiProxyOptions,
-    target: virtMeta.clusterApi,
     logLevel: 'debug',
   };
 
   inventoryApiProxyOptions = {
     ...inventoryApiProxyOptions,
-    target: virtMeta.inventoryApi,
     logLevel: 'debug',
   };
 
   inventoryPayloadApiProxyOptions = {
     ...inventoryPayloadApiProxyOptions,
-    target: virtMeta.inventoryPayloadApi,
     logLevel: 'debug',
   };
 }


### PR DESCRIPTION
The URLs are provided by virt-operator via virtMeta.json file, so the proxified URLs shouldn't be hard coded in the UI. This pull request makes the proxy always use virtMeta values.

It also enabled debug mode for the proxy if `DEBUG` environment variable is set to `*`, i.e. enables debug for proxy at the same time as Node.

It also sets the `secure` attribute to `true` for clusterApi, as the CA certificate is configured at Node level. Not sure it will works.