### PR TITLE
Fix mock dev mode: only set up proxy if not in mock mode

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -71,57 +71,59 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
   });
 }
 
-let clusterApiProxyOptions = {
-  target: virtMeta.clusterApi,
-  changeOrigin: true,
-  pathRewrite: {
-    '^/cluster-api/': '/',
-  },
-  logLevel: process.env.DEBUG ? 'debug' : 'info',
-};
-
-let inventoryApiProxyOptions = {
-  target: virtMeta.inventoryApi,
-  changeOrigin: true,
-  pathRewrite: {
-    '^/inventory-api/': '/',
-  },
-  logLevel: process.env.DEBUG ? 'debug' : 'info',
-};
-
-let inventoryPayloadApiProxyOptions = {
-  target: virtMeta.inventoryPayloadApi,
-  changeOrigin: true,
-  pathRewrite: {
-    '^/inventory-payload-api/': '/',
-  },
-  logLevel: process.env.DEBUG ? 'debug' : 'info',
-};
-
-if (process.env['NODE_ENV'] === 'development') {
-  clusterApiProxyOptions = {
-    ...clusterApiProxyOptions,
-    secure: false,
+if (process.env['DATA_SOURCE'] !== 'mock') {
+  let clusterApiProxyOptions = {
+    target: virtMeta.clusterApi,
+    changeOrigin: true,
+    pathRewrite: {
+      '^/cluster-api/': '/',
+    },
+    logLevel: process.env.DEBUG ? 'debug' : 'info',
   };
 
-  inventoryApiProxyOptions = {
-    ...inventoryApiProxyOptions,
-    secure: false,
+  let inventoryApiProxyOptions = {
+    target: virtMeta.inventoryApi,
+    changeOrigin: true,
+    pathRewrite: {
+      '^/inventory-api/': '/',
+    },
+    logLevel: process.env.DEBUG ? 'debug' : 'info',
   };
 
-  inventoryPayloadApiProxyOptions = {
-    ...inventoryPayloadApiProxyOptions,
-    secure: false,
+  let inventoryPayloadApiProxyOptions = {
+    target: virtMeta.inventoryPayloadApi,
+    changeOrigin: true,
+    pathRewrite: {
+      '^/inventory-payload-api/': '/',
+    },
+    logLevel: process.env.DEBUG ? 'debug' : 'info',
   };
+
+  if (process.env['NODE_ENV'] === 'development') {
+    clusterApiProxyOptions = {
+      ...clusterApiProxyOptions,
+      secure: false,
+    };
+
+    inventoryApiProxyOptions = {
+      ...inventoryApiProxyOptions,
+      secure: false,
+    };
+
+    inventoryPayloadApiProxyOptions = {
+      ...inventoryPayloadApiProxyOptions,
+      secure: false,
+    };
+  }
+
+  const clusterApiProxy = createProxyMiddleware(clusterApiProxyOptions);
+  const inventoryApiProxy = createProxyMiddleware(inventoryApiProxyOptions);
+  const inventoryPayloadApiProxy = createProxyMiddleware(inventoryPayloadApiProxyOptions);
+
+  app.use('/cluster-api/', clusterApiProxy);
+  app.use('/inventory-api/', inventoryApiProxy);
+  app.use('/inventory-payload-api/', inventoryPayloadApiProxy);
 }
-
-const clusterApiProxy = createProxyMiddleware(clusterApiProxyOptions);
-const inventoryApiProxy = createProxyMiddleware(inventoryApiProxyOptions);
-const inventoryPayloadApiProxy = createProxyMiddleware(inventoryPayloadApiProxyOptions);
-
-app.use('/cluster-api/', clusterApiProxy);
-app.use('/inventory-api/', inventoryApiProxy);
-app.use('/inventory-payload-api/', inventoryPayloadApiProxy);
 
 app.get('*', (_, res) => {
   if (process.env['NODE_ENV'] === 'development' || process.env['DATA_SOURCE'] === 'mock') {


### PR DESCRIPTION
@gildub we broke mock mode when we changed the `target` property of the proxy config to use virtMeta in server.js. When you're in mock mode, those virtMeta paths are undefined, so HPM complains:

```
Error: [HPM] Missing "target" option. Example: {target: "http://www.example.org"}
```

This only affects `yarn start:dev` and not the surge.sh preview links, because those don't run Express.

This PR puts all of the proxy config behind a condition so it only runs when not in mock mode.