### PR TITLE
Cleanup after PF bump, address tree selection corner case

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.css
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.css
@@ -1,10 +1,18 @@
-/* This shouldn't be necessary, there is a weird spacing bug in PF TreeView. */
-/* https://github.com/patternfly/patternfly/issues/3532 */
+/* This shouldn't be necessary, there is (still) a weird spacing bug in PF TreeView. */
+/* https://github.com/patternfly/patternfly-react/issues/5165 */
 
 .plan-wizard-filter-vms-form .pf-c-tree-view .pf-c-tree-view__node-toggle-icon {
   padding-right: var(--pf-global--spacer--sm);
+  margin-left: -24px; /* negative spacer--lg, couldn't use it in a calc() */
 }
 
-.plan-wizard-filter-vms-form .pf-c-tree-view li.pf-c-tree-view__list-item:not(.pf-m-expandable) {
-  padding-left: var(--pf-global--spacer--lg);
+/* Exclude root node from negative margin */
+.plan-wizard-filter-vms-form
+  .pf-c-tree-view
+  > ul
+  > li.pf-c-tree-view__list-item
+  > div.pf-c-tree-view__content
+  > button.pf-c-tree-view__node
+  > .pf-c-tree-view__node-toggle-icon {
+  margin-left: var(--pf-global--spacer--md);
 }

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -85,9 +85,7 @@ const convertVMwareTreeNode = (
     children: filterAndConvertVMwareTreeChildren(node.children, searchText, isNodeSelected),
     checkProps: {
       'aria-label': `Select ${node.kind} ${node.object?.name || ''}`,
-      checked: isNodeSelected(node),
-      // TODO: replace this ref with a null `checked` value when https://github.com/patternfly/patternfly-react/pull/5150 is released
-      ref: (elem: HTMLInputElement) => elem && (elem.indeterminate = isPartiallyChecked),
+      checked: isPartiallyChecked ? null : isNodeSelected(node),
     },
     icon:
       node.kind === 'Cluster' ? (
@@ -132,9 +130,7 @@ export const filterAndConvertVMwareTree = (
       id: 'converted-root',
       checkProps: {
         'aria-label': 'Select all datacenters',
-        checked: areAllSelected,
-        // TODO: replace this ref with a null `checked` value when https://github.com/patternfly/patternfly-react/pull/5150 is released
-        ref: (elem: HTMLInputElement) => elem && (elem.indeterminate = isPartiallyChecked),
+        checked: isPartiallyChecked ? null : areAllSelected,
       },
       children: filterAndConvertVMwareTreeChildren(rootNode.children, searchText, isNodeSelected),
     },

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -48,16 +48,6 @@ const subtreeMatchesSearch = (node: VMwareTree, searchText: string) => {
   return node.children && node.children.some((child) => subtreeMatchesSearch(child, searchText));
 };
 
-const areAllDescendantsSelected = (
-  node: VMwareTree,
-  isNodeSelected: (node: VMwareTree) => boolean
-) =>
-  node.children
-    ? node.children
-        .filter((child) => child.kind !== 'VM')
-        .every((child) => areAllDescendantsSelected(child, isNodeSelected))
-    : isNodeSelected(node);
-
 const areSomeDescendantsSelected = (
   node: VMwareTree,
   isNodeSelected: (node: VMwareTree) => boolean
@@ -76,9 +66,7 @@ const convertVMwareTreeNode = (
   isNodeSelected: (node: VMwareTree) => boolean
 ): TreeViewDataItem => {
   const isPartiallyChecked =
-    !isNodeSelected(node) &&
-    !areAllDescendantsSelected(node, isNodeSelected) &&
-    areSomeDescendantsSelected(node, isNodeSelected);
+    !isNodeSelected(node) && areSomeDescendantsSelected(node, isNodeSelected);
   return {
     name: node.object?.name || '',
     id: node.object?.selfLink,
@@ -121,9 +109,7 @@ export const filterAndConvertVMwareTree = (
 ): TreeViewDataItem[] => {
   if (!rootNode) return [];
   const isPartiallyChecked =
-    !areAllSelected &&
-    !areAllDescendantsSelected(rootNode, isNodeSelected) &&
-    areSomeDescendantsSelected(rootNode, isNodeSelected);
+    !areAllSelected && areSomeDescendantsSelected(rootNode, isNodeSelected);
   return [
     {
       name: 'All datacenters',


### PR DESCRIPTION
* Resolves #235 
* Tried to address #210, but there are still upstream issues to deal with. 
  * Changes our temporary tree view CSS so things still look correct (the tree CSS is still broken, just in a different way 🙃)
* Fixes a corner case I missed in #234.
  * If a node is not selected but all of its children are, it should still appear partially selected.


