### PR TITLE
Restore VMware provider hosts page, add host network selection

### DIFF
--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -3,13 +3,11 @@ import {
   PageSection,
   Level,
   LevelItem,
-  Bullseye,
   Card,
   CardBody,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
-  Spinner,
   Title,
   Alert,
 } from '@patternfly/react-core';
@@ -20,19 +18,20 @@ import VMwareProviderHostsTable from './components/VMwareProviderHostsTable';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useHostsQuery } from '@app/queries';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+
 export interface IHostsMatchParams {
   url: string;
-  providerId: string;
+  providerName: string;
 }
 
 export const HostsPage: React.FunctionComponent = () => {
   const match = useRouteMatch<IHostsMatchParams>({
-    path: '/providers/:providerId',
+    path: '/providers/:providerName',
     strict: true,
     sensitive: true,
   });
 
-  const hostsQuery = useHostsQuery(match?.params?.providerId);
+  const hostsQuery = useHostsQuery(match?.params.providerName);
 
   return (
     <>
@@ -43,21 +42,22 @@ export const HostsPage: React.FunctionComponent = () => {
               <BreadcrumbItem>
                 <Link to={`/providers`}>Providers</Link>
               </BreadcrumbItem>
-              <BreadcrumbItem isActive>{match?.params.providerId} - hosts</BreadcrumbItem>
+              <BreadcrumbItem>{match?.params.providerName}</BreadcrumbItem>
+              <BreadcrumbItem isActive>Hosts</BreadcrumbItem>
             </Breadcrumb>
           </LevelItem>
         </Level>
         <Level className={spacing.mtLg}>
           <LevelItem>
-            <Title headingLevel="h1">Hosts - {match?.params.providerId}</Title>
+            <Title headingLevel="h1">Hosts - {match?.params.providerName}</Title>
           </LevelItem>
         </Level>
       </PageSection>
       <PageSection>
         <Card>
-          {hostsQuery.isLoading ? (
+          {hostsQuery.isIdle || hostsQuery.isLoading ? (
             <LoadingEmptyState />
-          ) : hostsQuery.isError || !match?.params.providerId ? (
+          ) : hostsQuery.isError || !match?.params?.providerName ? (
             <Alert variant="danger" isInline title="Error loading hosts" />
           ) : (
             <CardBody>
@@ -71,7 +71,7 @@ export const HostsPage: React.FunctionComponent = () => {
                 </EmptyState>
               ) : (
                 <VMwareProviderHostsTable
-                  providerId={match?.params.providerId}
+                  providerName={match?.params.providerName || ''}
                   hosts={hostsQuery?.data}
                 />
               )}

--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -19,7 +19,9 @@ import ProviderStatus from '../ProviderStatus';
 import { mostSeriousCondition } from '@app/common/helpers';
 
 import './VMwareProvidersTable.css';
-import { ProviderType, VIRT_META } from '@app/common/constants';
+import { ProviderType } from '@app/common/constants';
+import { Link } from 'react-router-dom';
+import { OutlinedHddIcon } from '@patternfly/react-icons';
 
 interface IVMwareProvidersTableProps {
   providers: IVMwareProvider[];
@@ -55,13 +57,6 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
     selectAll,
     isItemSelected,
   } = useSelectionState<IVMwareProvider>({ items: sortedItems });
-  const {
-    toggleItemSelected: toggleProviderExpanded,
-    isItemSelected: isItemExpanded,
-  } = useSelectionState<IVMwareProvider>({
-    items: sortedItems,
-    isEqual: (a, b) => a.name === b.name,
-  });
 
   const inventoryDownloadURL = `/inventory-payload-api/api/v1/extract?providers=${selectedItems
     .map((provider) => `${provider.namespace}/${provider.name}`)
@@ -97,10 +92,8 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
   currentPageItems.forEach((provider: IVMwareProvider) => {
     const { clusterCount, hostCount, vmCount, networkCount, datastoreCount } = provider;
     const isSelected = isItemSelected(provider);
-    const isExpanded = isItemExpanded(provider);
     rows.push({
       meta: { provider },
-      isOpen: isExpanded,
       cells: [
         {
           title: (
@@ -118,8 +111,6 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
         provider.object.spec.url,
         clusterCount,
         {
-          /*
-          // TODO (post-beta): reintroduce the link to /providers/* when we resolve https://github.com/konveyor/virt-ui/issues/138
           title: (
             <>
               <Link to={`/providers/${provider.name}`}>
@@ -127,8 +118,6 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
               </Link>
             </>
           ),
-          */
-          title: hostCount,
         },
         vmCount,
         networkCount,
@@ -168,9 +157,6 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
         rows={rows}
         sortBy={sortBy}
         onSort={onSort}
-        onExpand={(_event, _rowIndex, _colIndex, _isOpen, rowData) => {
-          toggleProviderExpanded(rowData.meta.provider);
-        }}
       >
         <TableHeader />
         <TableBody />

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.css
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.css
@@ -1,3 +1,3 @@
 .selectNetworkModal .extraSelectMargin {
-  margin-bottom: 100px;
+  margin-bottom: 200px;
 }

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.css
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.css
@@ -1,3 +1,3 @@
 .selectNetworkModal .extraSelectMargin {
-  margin-bottom: 200px;
+  margin-bottom: 184px;
 }

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -20,14 +20,12 @@ interface ISelectNetworkModalProps {
   onClose: () => void;
 }
 
-const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
-  selectedHosts,
-  onClose,
-}: ISelectNetworkModalProps) => {
+// TODO support prefilling if all hosts already have the same network?
+const useSelectNetworkFormState = () => {
   const isReusingCredentials = useFormField(true, yup.boolean().required());
   const usernameSchema = yup.string().max(320).label('Host admin username');
   const passwordSchema = yup.string().max(256).label('Host admin password');
-  const form = useFormState({
+  return useFormState({
     selectedNetworkAdapter: useFormField<IHostNetworkAdapter | null>(
       null,
       yup.mixed<IHostNetworkAdapter>().label('Host network').required()
@@ -42,6 +40,15 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
     ),
     isReusingCredentials,
   });
+};
+
+export type SelectNetworkFormValues = ReturnType<typeof useSelectNetworkFormState>['values'];
+
+const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
+  selectedHosts,
+  onClose,
+}: ISelectNetworkModalProps) => {
+  const form = useSelectNetworkFormState();
 
   const commonNetworkAdapters: IHostNetworkAdapter[] = selectedHosts[0].networkAdapters.filter(
     ({ name, ipAddress }) =>

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -78,10 +78,8 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   const form = useSelectNetworkFormState(selectedHosts, hostConfigs, provider);
 
   const commonNetworkAdapters: IHostNetworkAdapter[] = selectedHosts[0].networkAdapters.filter(
-    ({ name, ipAddress }) =>
-      selectedHosts.every((host) =>
-        host.networkAdapters.some((na) => na.name === name && na.ipAddress === ipAddress)
-      )
+    ({ ipAddress }) =>
+      selectedHosts.every((host) => host.networkAdapters.some((na) => na.ipAddress === ipAddress))
   );
 
   const networkOptions = commonNetworkAdapters.map((networkAdapter) => ({

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as yup from 'yup';
-import { Modal, Button, Form, FormGroup, Checkbox } from '@patternfly/react-core';
+import { Modal, Button, Form, FormGroup, Checkbox, Stack, Flex } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   useFormState,
@@ -10,24 +10,42 @@ import {
 } from '@konveyor/lib-ui';
 
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import { IHost, IHostNetworkAdapter } from '@app/queries/types';
+import { IHost, IHostConfig, IHostNetworkAdapter, IVMwareProvider } from '@app/queries/types';
 
 import './SelectNetworkModal.css';
 import { formatHostNetworkAdapter } from './helpers';
+import { getExistingHostConfigs, useConfigureHostsMutation } from '@app/queries';
+import MutationStatus from '@app/common/components/MutationStatus';
 
 interface ISelectNetworkModalProps {
   selectedHosts: IHost[];
+  hostConfigs: IHostConfig[];
+  provider: IVMwareProvider;
   onClose: () => void;
 }
 
-// TODO support prefilling if all hosts already have the same network?
-const useSelectNetworkFormState = () => {
+const useSelectNetworkFormState = (
+  selectedHosts: IHost[],
+  hostConfigs: IHostConfig[],
+  provider: IVMwareProvider
+) => {
+  const existingHostConfigs = getExistingHostConfigs(selectedHosts, hostConfigs, provider);
+  const existingIpAddresses = existingHostConfigs
+    .map((config) => config?.spec.ipAddress)
+    .filter((ip) => !!ip) as string[];
+  const allOnSameIp = Array.from(new Set(existingIpAddresses)).length === 1;
+  const preselectedAdapter = allOnSameIp
+    ? selectedHosts[0].networkAdapters.find(
+        (adapter) => adapter.ipAddress === existingIpAddresses[0]
+      ) || null
+    : null;
+
   const isReusingCredentials = useFormField(true, yup.boolean().required());
   const usernameSchema = yup.string().max(320).label('Host admin username');
   const passwordSchema = yup.string().max(256).label('Host admin password');
   return useFormState({
     selectedNetworkAdapter: useFormField<IHostNetworkAdapter | null>(
-      null,
+      preselectedAdapter,
       yup.mixed<IHostNetworkAdapter>().label('Host network').required()
     ),
     adminUsername: useFormField(
@@ -46,9 +64,18 @@ export type SelectNetworkFormValues = ReturnType<typeof useSelectNetworkFormStat
 
 const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   selectedHosts,
+  hostConfigs,
+  provider,
   onClose,
 }: ISelectNetworkModalProps) => {
-  const form = useSelectNetworkFormState();
+  const [configureHosts, configureHostsResult] = useConfigureHostsMutation(
+    provider,
+    selectedHosts,
+    hostConfigs,
+    onClose
+  );
+
+  const form = useSelectNetworkFormState(selectedHosts, hostConfigs, provider);
 
   const commonNetworkAdapters: IHostNetworkAdapter[] = selectedHosts[0].networkAdapters.filter(
     ({ name, ipAddress }) =>
@@ -63,14 +90,6 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
     props: { description: `${networkAdapter.linkSpeed} Mbps; MTU: ${networkAdapter.mtu}` },
   }));
 
-  const add = () => {
-    alert('TODO');
-    if (form.isValid) {
-      console.log('TODO: submit form!', form.values);
-      onClose();
-    }
-  };
-
   return (
     <Modal
       className="selectNetworkModal"
@@ -78,8 +97,47 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
       title="Select migration network"
       isOpen
       onClose={onClose}
+      footer={
+        <Stack hasGutter>
+          <MutationStatus
+            results={[configureHostsResult]}
+            errorTitles={['Error configuring hosts']}
+          />
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <Button
+              key="confirm"
+              variant="primary"
+              isDisabled={!form.isValid || configureHostsResult.isLoading}
+              onClick={() => {
+                if (form.isValid) {
+                  configureHosts(form.values);
+                }
+              }}
+            >
+              Add
+            </Button>
+            <Button
+              key="cancel"
+              variant="link"
+              onClick={onClose}
+              isDisabled={configureHostsResult.isLoading}
+            >
+              Cancel
+            </Button>
+          </Flex>
+        </Stack>
+      }
       actions={[
-        <Button key="confirm" variant="primary" isDisabled={!form.isValid} onClick={add}>
+        <Button
+          key="confirm"
+          variant="primary"
+          isDisabled={!form.isValid || configureHostsResult.isLoading}
+          onClick={() => {
+            if (form.isValid) {
+              configureHosts(form.values);
+            }
+          }}
+        >
           Add
         </Button>,
         <Button key="cancel" variant="link" onClick={onClose}>

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -13,22 +13,19 @@ import { usePaginationState, useSortState } from '@app/common/hooks';
 import { useSelectionState } from '@konveyor/lib-ui';
 import { IHost, IVMwareProvider } from '@app/queries/types';
 import SelectNetworkModal from './SelectNetworkModal';
-import { useHostConfigsQuery, useProvidersQuery } from '@app/queries';
+import { useHostConfigsQuery } from '@app/queries';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { findSelectedNetworkAdapter, formatHostNetworkAdapter } from './helpers';
 
 interface IVMwareProviderHostsTableProps {
-  providerName: string;
+  provider: IVMwareProvider;
   hosts: IHost[];
 }
 
 const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTableProps> = ({
-  providerName,
+  provider,
   hosts,
 }: IVMwareProviderHostsTableProps) => {
-  const providersQuery = useProvidersQuery();
-  const provider = providersQuery.data?.vsphere.find((provider) => provider.name === providerName);
-
   const hostConfigsQuery = useHostConfigsQuery();
   const hostConfigs = hostConfigsQuery.data?.items || [];
 
@@ -40,7 +37,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
   ];
 
   const getCells = (host: IHost) => {
-    const networkAdapter = findSelectedNetworkAdapter(host, hostConfigs, provider || null);
+    const networkAdapter = findSelectedNetworkAdapter(host, hostConfigs, provider);
     return [
       host.name,
       networkAdapter ? formatHostNetworkAdapter(networkAdapter) : '(default)',
@@ -68,10 +65,8 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
 
   const [isSelectNetworkModalOpen, setIsSelectNetworkModalOpen] = React.useState(false);
 
-  return providersQuery.isLoading || hostConfigsQuery.isLoading ? (
+  return hostConfigsQuery.isLoading ? (
     <LoadingEmptyState />
-  ) : providersQuery.isError ? (
-    <Alert variant="danger" isInline title="Error loading providers" />
   ) : hostConfigsQuery.isError ? (
     <Alert variant="danger" isInline title="Error loading host configurations" />
   ) : (
@@ -92,7 +87,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       </Level>
       <Table
         className="provider-inner-hosts-table"
-        aria-label={`Hosts table for provider ${providerName}`}
+        aria-label={`Hosts table for provider ${provider.name}`}
         cells={columns}
         rows={rows}
         sortBy={sortBy}

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -1,32 +1,39 @@
 import * as React from 'react';
 import { Button, Level, LevelItem, Pagination } from '@patternfly/react-core';
-import { Table, TableHeader, TableBody, sortable, ICell, IRow } from '@patternfly/react-table';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  ICell,
+  IRow,
+  cellWidth,
+} from '@patternfly/react-table';
 import { usePaginationState, useSortState } from '@app/common/hooks';
 import { useSelectionState } from '@konveyor/lib-ui';
 import { IHost } from '@app/queries/types';
-import { formatHostNetwork } from './helpers';
 import SelectNetworkModal from './SelectNetworkModal';
 
 interface IVMwareProviderHostsTableProps {
-  providerId?: string;
+  providerName: string;
   hosts: IHost[];
 }
 
 const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTableProps> = ({
-  providerId,
+  providerName,
   hosts,
 }: IVMwareProviderHostsTableProps) => {
   console.log(hosts);
   const columns: ICell[] = [
     { title: 'Name', transforms: [sortable] },
-    { title: 'Network for migration data transfer', transforms: [sortable] },
+    { title: 'Network for migration data transfer', transforms: [sortable, cellWidth(30)] },
     { title: 'Bandwidth', transforms: [sortable] },
     { title: 'MTU', transforms: [sortable] },
   ];
 
   const getSortValues = (host: IHost) => {
-    const { name, network, bandwidth, mtu } = host;
-    return ['', name, formatHostNetwork(network), bandwidth, mtu];
+    // TODO correlate inventory host with host CR to find selected network
+    return ['', host.name, '(default)', '', ''];
   };
 
   const { sortBy, onSort, sortedItems } = useSortState(hosts, getSortValues);
@@ -36,11 +43,11 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
   });
 
   const rows: IRow[] = sortedItems.map((host: IHost) => {
-    const { name } = host;
+    // TODO correlate inventory host with host CR to find selected network
     return {
       meta: { host },
       selected: selectedItems.includes(host),
-      cells: [name, formatHostNetwork(host.network), host.bandwidth, host.mtu],
+      cells: [host.name, '(default)', '', ''],
     };
   });
 
@@ -65,7 +72,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
         </Level>
         <Table
           className="provider-inner-hosts-table"
-          aria-label={`Hosts table for provider ${providerId}`}
+          aria-label={`Hosts table for provider ${providerName}`}
           cells={columns}
           rows={rows}
           sortBy={sortBy}

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -1,4 +1,19 @@
-import { IHostNetworkAdapter } from '@app/queries/types';
+import { configMatchesHost } from '@app/queries';
+import { IHost, IHostConfig, IHostNetworkAdapter, IVMwareProvider } from '@app/queries/types';
+
+export const findSelectedNetworkAdapter = (
+  host: IHost,
+  hostConfigs: IHostConfig[],
+  provider: IVMwareProvider | null
+): IHostNetworkAdapter | null => {
+  const matchingConfig =
+    provider && hostConfigs.find((config) => configMatchesHost(config, host, provider));
+  if (!matchingConfig) return null;
+  return (
+    host.networkAdapters.find((adapter) => adapter.ipAddress === matchingConfig?.spec.ipAddress) ||
+    null
+  );
+};
 
 export const formatHostNetworkAdapter = (network: IHostNetworkAdapter): string => {
   if (network) {

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -1,9 +1,8 @@
-import { IHostNetwork } from '@app/queries/types';
+import { IHostNetworkAdapter } from '@app/queries/types';
 
-export const formatHostNetwork = (network: IHostNetwork): string => {
+export const formatHostNetworkAdapter = (network: IHostNetworkAdapter): string => {
   if (network) {
-    const { name, address, isDefault } = network;
-    return `${name} - ${address}${isDefault ? ' (default)' : ''}`;
+    return `${network.name} - ${network.ipAddress}`;
   }
   return 'Network not found';
 };

--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -37,6 +37,7 @@ export enum VirtResourceKind {
   StorageMap = 'storagemaps',
   Plan = 'plans',
   Migration = 'migrations',
+  Host = 'hosts',
 }
 
 export const secretResource = new CoreNamespacedResource(

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -20,7 +20,7 @@ import { CLUSTER_API_VERSION, VIRT_META } from '@app/common/constants';
 export const hostConfigResource = new VirtResource(VirtResourceKind.Host, VIRT_META.namespace);
 
 // TODO handle error messages? (query.status will correctly show 'error', but error messages aren't collected)
-export const useHostsQuery = (provider?: IVMwareProvider): QueryResult<IHost[]> => {
+export const useHostsQuery = (provider: IVMwareProvider | null): QueryResult<IHost[]> => {
   const result = useMockableQuery<IHost[]>(
     {
       queryKey: 'hosts',

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -134,7 +134,7 @@ export const useConfigureHostsMutation = (
       // Else, patches the first available secret and reuses it for all hosts.
       const existingSecrets = existingHostConfigs
         .map((hostConfig) => hostConfig?.spec.secret)
-        .filter((secret) => !!secret) as INameNamespaceRef[];
+        .filter((secret) => secret?.name && secret?.namespace) as INameNamespaceRef[];
       const secretBeingReusedRef = existingSecrets.length > 0 ? existingSecrets[0] : null;
       const newSecret = generateSecret(values, secretBeingReusedRef, provider);
       let secretResult: IKubeResponse<INewSecret>;

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -6,13 +6,19 @@ import {
   sortResultsByName,
   isSameResource,
   useMockableMutation,
+  nameAndNamespace,
+  mockKubeList,
 } from './helpers';
-import { MOCK_HOSTS } from './mocks/hosts.mock';
-import { IHost, IHostConfig, IVMwareProvider } from './types';
+import { MOCK_HOSTS, MOCK_HOST_CONFIGS } from './mocks/hosts.mock';
+import { IHost, IHostConfig, INameNamespaceRef, INewSecret, IVMwareProvider } from './types';
 import { useProvidersQuery } from '.';
 import { useAuthorizedFetch, useAuthorizedK8sClient } from './fetchHelpers';
-import { IKubeResponse, KubeClientError } from '@app/client/types';
+import { IKubeList, IKubeResponse, KubeClientError } from '@app/client/types';
 import { SelectNetworkFormValues } from '@app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal';
+import { secretResource, VirtResource, VirtResourceKind } from '@app/client/helpers';
+import { CLUSTER_API_VERSION, VIRT_META } from '@app/common/constants';
+
+export const hostConfigResource = new VirtResource(VirtResourceKind.Host, VIRT_META.namespace);
 
 // TODO handle error messages? (query.status will correctly show 'error', but error messages aren't collected)
 export const useHostsQuery = (providerName?: string): QueryResult<IHost[]> => {
@@ -35,8 +41,67 @@ export const useHostsQuery = (providerName?: string): QueryResult<IHost[]> => {
   return sortResultsByName<IHost>(result);
 };
 
+export const useHostConfigsQuery = (providerName?: string): QueryResult<IKubeList<IHostConfig>> => {
+  const client = useAuthorizedK8sClient();
+  return useMockableQuery<IKubeList<IHostConfig>>(
+    {
+      queryKey: ['host-configs', providerName],
+      queryFn: async () => (await client.list<IKubeList<IHostConfig>>(hostConfigResource)).data,
+      config: {
+        refetchInterval: usePollingContext().refetchInterval,
+      },
+    },
+    mockKubeList(MOCK_HOST_CONFIGS, 'Host')
+  );
+};
+
 const configMatchesHost = (config: IHostConfig, host: IHost, provider: IVMwareProvider) =>
   isSameResource(config.spec.provider, provider) && host.id === config.spec.id;
+
+const generateSecret = (
+  values: SelectNetworkFormValues,
+  secretBeingReusedRef: INameNamespaceRef | null,
+  provider: IVMwareProvider
+): INewSecret => ({
+  apiVersion: 'v1',
+  data: {
+    user: values.adminUsername && btoa(values.adminUsername),
+    password: values.adminPassword && btoa(values.adminPassword),
+  },
+  kind: 'Secret',
+  metadata: {
+    ...(secretBeingReusedRef || {
+      generateName: `${provider.name}-`,
+      namespace: VIRT_META.namespace,
+    }),
+    labels: {
+      createdForResourceType: VirtResourceKind.Provider,
+      createdForResource: provider.name,
+    },
+  },
+  type: 'Opaque',
+});
+
+const generateHostConfig = (
+  values: SelectNetworkFormValues,
+  existingConfig: IHostConfig | null,
+  host: IHost,
+  provider: IVMwareProvider,
+  secretRef: INameNamespaceRef | null
+): IHostConfig => ({
+  apiVersion: CLUSTER_API_VERSION,
+  kind: 'Host',
+  metadata: existingConfig?.metadata || {
+    name: `host-${host.id}-config`,
+    namespace: VIRT_META.namespace,
+  },
+  spec: {
+    id: host.id,
+    ipAddress: values.selectedNetworkAdapter?.ipAddress || '',
+    provider: nameAndNamespace(provider),
+    secret: secretRef || {},
+  },
+});
 
 export const useConfigureHostsMutation = (
   provider: IVMwareProvider,
@@ -44,7 +109,7 @@ export const useConfigureHostsMutation = (
   allHostConfigs: IHostConfig[],
   onSuccess?: () => void
 ): MutationResultPair<
-  IKubeResponse<IHostConfig>,
+  IKubeResponse<IHostConfig>[],
   KubeClientError,
   SelectNetworkFormValues,
   unknown
@@ -54,29 +119,55 @@ export const useConfigureHostsMutation = (
   const { pollFasterAfterMutation } = usePollingContext();
 
   const configureHosts = async (values: SelectNetworkFormValues) => {
-    // TODO Use allHostConfigs to determine if each host needs to create or patch a host CR
-    // TODO If reusing creds, don't pass any secrets for any of them (pass empty objects to remove secrets?)
-    // TODO If not reusing creds, look for existing secrets:
-    //   - if any exist, patch them all with the new creds and pass the first matching one to all CRs without a secret
-    //   - else, create a new secret and pass it to all the host CRs.
-    // Create or patch secrets
-    // Create or patch Host CRs
-    // - if any failed, and we created secrets for those, roll those back?
-
     const existingHostConfigs = selectedHosts.map((host) =>
       allHostConfigs.find((config) => configMatchesHost(config, host, provider))
     );
+    let secretRef: INameNamespaceRef | null = null;
+    if (!values.isReusingCredentials) {
+      // If none of these hosts are configured with a secret, creates a new one.
+      // Else, patches the first available secret and reuses it for all hosts.
+      const existingSecrets = existingHostConfigs
+        .map((hostConfig) => hostConfig?.spec.secret)
+        .filter((secret) => !!secret) as INameNamespaceRef[];
+      const secretBeingReusedRef = existingSecrets.length > 0 ? existingSecrets[0] : null;
+      const newSecret = generateSecret(values, secretBeingReusedRef, provider);
+      let secretResult: IKubeResponse<INewSecret>;
+      if (secretBeingReusedRef) {
+        secretResult = await client.patch(secretResource, secretBeingReusedRef.name, newSecret);
+        secretRef = secretBeingReusedRef;
+      } else {
+        secretResult = await client.create(secretResource, newSecret);
+        secretRef = nameAndNamespace(secretResult.data.metadata);
+      }
+    }
+    const hostConfigResults = await Promise.all(
+      selectedHosts.map(async (host, index) => {
+        const existingConfig = existingHostConfigs[index] || null;
+        const newConfig = generateHostConfig(values, existingConfig, host, provider, secretRef);
+        if (existingConfig) {
+          return await client.patch<IHostConfig>(
+            hostConfigResource,
+            existingConfig.metadata.name,
+            newConfig
+          );
+        } else {
+          return await client.create<IHostConfig>(hostConfigResource, newConfig);
+        }
+      })
+    );
+    return hostConfigResults;
   };
 
-  return useMockableMutation<IKubeResponse<IHostConfig>, KubeClientError, SelectNetworkFormValues>(
-    configureHosts,
-    {
-      onSuccess: () => {
-        queryCache.invalidateQueries('hosts');
-        queryCache.invalidateQueries('hostconfigs');
-        pollFasterAfterMutation();
-        onSuccess && onSuccess();
-      },
-    }
-  );
+  return useMockableMutation<
+    IKubeResponse<IHostConfig>[],
+    KubeClientError,
+    SelectNetworkFormValues
+  >(configureHosts, {
+    onSuccess: () => {
+      queryCache.invalidateQueries('hosts');
+      queryCache.invalidateQueries('hostconfigs');
+      pollFasterAfterMutation();
+      onSuccess && onSuccess();
+    },
+  });
 };

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -1,10 +1,18 @@
-import { QueryResult } from 'react-query';
+import { MutationResultPair, QueryResult, useQueryCache } from 'react-query';
 import { usePollingContext } from '@app/common/context';
-import { useMockableQuery, getInventoryApiUrl, sortResultsByName } from './helpers';
+import {
+  useMockableQuery,
+  getInventoryApiUrl,
+  sortResultsByName,
+  isSameResource,
+  useMockableMutation,
+} from './helpers';
 import { MOCK_HOSTS } from './mocks/hosts.mock';
-import { IHost } from './types';
+import { IHost, IHostConfig, IVMwareProvider } from './types';
 import { useProvidersQuery } from '.';
-import { useAuthorizedFetch } from './fetchHelpers';
+import { useAuthorizedFetch, useAuthorizedK8sClient } from './fetchHelpers';
+import { IKubeResponse, KubeClientError } from '@app/client/types';
+import { SelectNetworkFormValues } from '@app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal';
 
 // TODO handle error messages? (query.status will correctly show 'error', but error messages aren't collected)
 export const useHostsQuery = (providerName?: string): QueryResult<IHost[]> => {
@@ -25,4 +33,50 @@ export const useHostsQuery = (providerName?: string): QueryResult<IHost[]> => {
     MOCK_HOSTS
   );
   return sortResultsByName<IHost>(result);
+};
+
+const configMatchesHost = (config: IHostConfig, host: IHost, provider: IVMwareProvider) =>
+  isSameResource(config.spec.provider, provider) && host.id === config.spec.id;
+
+export const useConfigureHostsMutation = (
+  provider: IVMwareProvider,
+  selectedHosts: IHost[],
+  allHostConfigs: IHostConfig[],
+  onSuccess?: () => void
+): MutationResultPair<
+  IKubeResponse<IHostConfig>,
+  KubeClientError,
+  SelectNetworkFormValues,
+  unknown
+> => {
+  const client = useAuthorizedK8sClient();
+  const queryCache = useQueryCache();
+  const { pollFasterAfterMutation } = usePollingContext();
+
+  const configureHosts = async (values: SelectNetworkFormValues) => {
+    // TODO Use allHostConfigs to determine if each host needs to create or patch a host CR
+    // TODO If reusing creds, don't pass any secrets for any of them (pass empty objects to remove secrets?)
+    // TODO If not reusing creds, look for existing secrets:
+    //   - if any exist, patch them all with the new creds and pass the first matching one to all CRs without a secret
+    //   - else, create a new secret and pass it to all the host CRs.
+    // Create or patch secrets
+    // Create or patch Host CRs
+    // - if any failed, and we created secrets for those, roll those back?
+
+    const existingHostConfigs = selectedHosts.map((host) =>
+      allHostConfigs.find((config) => configMatchesHost(config, host, provider))
+    );
+  };
+
+  return useMockableMutation<IKubeResponse<IHostConfig>, KubeClientError, SelectNetworkFormValues>(
+    configureHosts,
+    {
+      onSuccess: () => {
+        queryCache.invalidateQueries('hosts');
+        queryCache.invalidateQueries('hostconfigs');
+        pollFasterAfterMutation();
+        onSuccess && onSuccess();
+      },
+    }
+  );
 };

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -1,38 +1,179 @@
-import { IHost } from '../types/providers.types';
+import { IHost } from '../types/hosts.types';
 
-// TODO put this condition back when we don't directly import mocks into components anymore
-// if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-export const host1: IHost = {
-  name: 'host1',
-  network: {
-    name: 'storage network',
-    address: '192.168.0.1/24',
-    isDefault: true,
-  },
-  bandwidth: '1 GB/s',
-  mtu: 1499,
-};
+export let MOCK_HOSTS: IHost[] = [];
 
-export const host2: IHost = {
-  name: 'host2',
-  network: {
-    name: 'compute network',
-    address: '192.168.0.2/24',
-    isDefault: false,
-  },
-  bandwidth: '2 GB/s',
-  mtu: 1400,
-};
+if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+  const host1: IHost = {
+    id: 'host-44',
+    parent: { kind: 'Cluster', id: 'domain-c26' },
+    revision: 1,
+    name: 'esx12.v2v.bos.redhat.com',
+    selfLink: '/namespaces/openshift-migration/providers/vsphere/test/hosts/host-44',
+    inMaintenance: false,
+    thumbprint: 'D3:47:18:B1:11:39:87:25:F4:52:B2:04:EC:85:88:FA:9D:78:73:11',
+    cpuSockets: 2,
+    cpuCores: 16,
+    productName: 'VMware ESXi',
+    productVersion: '6.5.0',
+    networking: {
+      vNICs: [
+        { key: 'key-vim.host.PhysicalNic-vmnic0', linkSpeed: 10000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic1', linkSpeed: 10000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic2', linkSpeed: 10000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic3', linkSpeed: 10000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic4', linkSpeed: 1000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic6', linkSpeed: 1000 },
+        { key: 'key-vim.host.PhysicalNic-vmnic7', linkSpeed: 1000 },
+      ],
+      pNICs: [
+        {
+          key: 'key-vim.host.VirtualNic-vmk2',
+          portGroup: 'VM_Migration',
+          dPortGroup: '',
+          ipAddress: '192.168.79.12',
+          mtu: 9000,
+        },
+        {
+          key: 'key-vim.host.VirtualNic-vmk0',
+          portGroup: 'Management Network',
+          dPortGroup: '',
+          ipAddress: '10.19.2.12',
+          mtu: 1500,
+        },
+        {
+          key: 'key-vim.host.VirtualNic-vmk1',
+          portGroup: 'VMkernel',
+          dPortGroup: '',
+          ipAddress: '172.31.2.12',
+          mtu: 1500,
+        },
+        {
+          key: 'key-vim.host.VirtualNic-vmk3',
+          portGroup: '',
+          dPortGroup: 'dvportgroup-48',
+          ipAddress: '192.168.61.12',
+          mtu: 1500,
+        },
+      ],
+      portGroups: [
+        {
+          key: 'key-vim.host.PortGroup-VM Network',
+          name: 'VM Network',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch0',
+        },
+        {
+          key: 'key-vim.host.PortGroup-Management Network',
+          name: 'Management Network',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch0',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VM_DHCP_Network',
+          name: 'VM_DHCP_Network',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch1',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VM_Storage',
+          name: 'VM_Storage',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch1',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VM_10G_Network',
+          name: 'VM_10G_Network',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch1',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VMkernel',
+          name: 'VMkernel',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch1',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VM_Isolated_67',
+          name: 'VM_Isolated_67',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch2',
+        },
+        {
+          key: 'key-vim.host.PortGroup-VM_Migration',
+          name: 'VM_Migration',
+          vSwitch: 'key-vim.host.VirtualSwitch-vSwitch2',
+        },
+      ],
+      switches: [
+        {
+          key: 'key-vim.host.VirtualSwitch-vSwitch0',
+          name: 'vSwitch0',
+          portGroups: [
+            'key-vim.host.PortGroup-VM Network',
+            'key-vim.host.PortGroup-Management Network',
+          ],
+          pNICs: ['key-vim.host.PhysicalNic-vmnic4'],
+        },
+        {
+          key: 'key-vim.host.VirtualSwitch-vSwitch1',
+          name: 'vSwitch1',
+          portGroups: [
+            'key-vim.host.PortGroup-VM_DHCP_Network',
+            'key-vim.host.PortGroup-VM_Storage',
+            'key-vim.host.PortGroup-VM_10G_Network',
+            'key-vim.host.PortGroup-VMkernel',
+          ],
+          pNICs: ['key-vim.host.PhysicalNic-vmnic1', 'key-vim.host.PhysicalNic-vmnic0'],
+        },
+        {
+          key: 'key-vim.host.VirtualSwitch-vSwitch2',
+          name: 'vSwitch2',
+          portGroups: [
+            'key-vim.host.PortGroup-VM_Isolated_67',
+            'key-vim.host.PortGroup-VM_Migration',
+          ],
+          pNICs: ['key-vim.host.PhysicalNic-vmnic3', 'key-vim.host.PhysicalNic-vmnic2'],
+        },
+      ],
+    },
+    networks: [
+      { kind: 'Network', id: 'network-31' },
+      { kind: 'Network', id: 'network-34' },
+      { kind: 'Network', id: 'network-723' },
+      { kind: 'Network', id: 'network-57' },
+      { kind: 'Network', id: 'network-33' },
+      { kind: 'Network', id: 'dvportgroup-47' },
+      { kind: 'Network', id: 'dvportgroup-48' },
+      { kind: 'Network', id: 'dvportgroup-49' },
+      { kind: 'Network', id: 'dvportgroup-53' },
+      { kind: 'Network', id: 'dvportgroup-56' },
+      { kind: 'Network', id: 'dvportgroup-54' },
+      { kind: 'Network', id: 'dvportgroup-55' },
+    ],
+    datastores: [
+      { kind: 'Datastore', id: 'datastore-35' },
+      { kind: 'Datastore', id: 'datastore-63' },
+      { kind: 'Datastore', id: 'datastore-45' },
+    ],
+    vms: [
+      { kind: 'VM', id: 'vm-2867' },
+      { kind: 'VM', id: 'vm-2781' },
+      { kind: 'VM', id: 'vm-2861' },
+      { kind: 'VM', id: 'vm-2860' },
+      { kind: 'VM', id: 'vm-2851' },
+      { kind: 'VM', id: 'vm-2847' },
+      { kind: 'VM', id: 'vm-74' },
+      { kind: 'VM', id: 'vm-2858' },
+      { kind: 'VM', id: 'vm-2834' },
+      { kind: 'VM', id: 'vm-2849' },
+    ],
+    networkAdapters: [
+      { name: 'VM_Migration', ipAddress: '192.168.79.12', linkSpeed: 10000, mtu: 9000 },
+      { name: 'VMkernel', ipAddress: '172.31.2.12', linkSpeed: 10000, mtu: 1500 },
+      { name: 'vDS-1', ipAddress: '192.168.61.12', linkSpeed: 10000, mtu: 1500 },
+      { name: 'Management Network', ipAddress: '10.19.2.12', linkSpeed: 1000, mtu: 1500 },
+    ],
+  };
 
-export const host3: IHost = {
-  name: 'host3',
-  network: {
-    name: 'management network',
-    address: '192.168.0.3/24',
-    isDefault: false,
-  },
-  bandwidth: '3 GB/s',
-  mtu: 1500,
-};
+  const host2 = {
+    ...host1,
+    id: 'host-29',
+    name: 'esx13.v2v.bos.redhat.com',
+    selfLink: '/namespaces/openshift-migration/providers/vsphere/test/hosts/host-29',
+  };
 
-export const MOCK_HOSTS: IHost[] = [host1, host2, host3];
+  MOCK_HOSTS = [host1, host2];
+}

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -1,6 +1,10 @@
-import { IHost } from '../types/hosts.types';
+import { CLUSTER_API_VERSION, VIRT_META } from '@app/common/constants';
+import { nameAndNamespace } from '../helpers';
+import { IHost, IHostConfig } from '../types/hosts.types';
+import { MOCK_PROVIDERS } from './providers.mock';
 
 export let MOCK_HOSTS: IHost[] = [];
+export let MOCK_HOST_CONFIGS: IHostConfig[] = [];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const host1: IHost = {
@@ -176,4 +180,20 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   };
 
   MOCK_HOSTS = [host1, host2];
+
+  MOCK_HOST_CONFIGS = [
+    {
+      apiVersion: CLUSTER_API_VERSION,
+      kind: 'Host',
+      metadata: {
+        name: `host-${host1.id}-config`,
+        namespace: VIRT_META.namespace,
+      },
+      spec: {
+        id: host1.id,
+        ipAddress: host1.networkAdapters[0].ipAddress,
+        provider: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
+      },
+    },
+  ];
 }

--- a/src/app/queries/mocks/providers.mock.ts
+++ b/src/app/queries/mocks/providers.mock.ts
@@ -51,7 +51,7 @@ const vmwareProvider1: IVMwareProvider = {
   },
   datacenterCount: 1,
   clusterCount: 2,
-  hostCount: 15,
+  hostCount: 2,
   vmCount: 41,
   networkCount: 8,
   datastoreCount: 3,

--- a/src/app/queries/types/hosts.types.ts
+++ b/src/app/queries/types/hosts.types.ts
@@ -56,7 +56,7 @@ export interface IHostConfig extends ICR {
     id: string;
     ipAddress: string;
     provider: INameNamespaceRef;
-    secret?: INameNamespaceRef;
+    secret?: Partial<INameNamespaceRef>;
     thumbprint?: string;
   };
   status?: {

--- a/src/app/queries/types/hosts.types.ts
+++ b/src/app/queries/types/hosts.types.ts
@@ -1,4 +1,4 @@
-import { IVMwareObjRef } from './common.types';
+import { ICR, INameNamespaceRef, IVMwareObjRef } from './common.types';
 
 export interface IHostNetworkAdapter {
   name: string;
@@ -47,4 +47,19 @@ export interface IHost {
   datastores: IVMwareObjRef[];
   vms: IVMwareObjRef[];
   networkAdapters: IHostNetworkAdapter[];
+}
+
+export interface IHostConfig extends ICR {
+  apiVersion: string;
+  kind: 'Host';
+  spec: {
+    id: string;
+    ipAddress: string;
+    provider: INameNamespaceRef;
+    secret?: INameNamespaceRef;
+    thumbprint?: string;
+  };
+  status?: {
+    observedGeneration: string;
+  };
 }

--- a/src/app/queries/types/hosts.types.ts
+++ b/src/app/queries/types/hosts.types.ts
@@ -1,0 +1,50 @@
+import { IVMwareObjRef } from './common.types';
+
+export interface IHostNetworkAdapter {
+  name: string;
+  ipAddress: string;
+  linkSpeed: number;
+  mtu: number;
+}
+
+export interface IHost {
+  id: string;
+  parent: IVMwareObjRef;
+  revision: number;
+  name: string;
+  selfLink: string;
+  inMaintenance: boolean;
+  thumbprint: string;
+  cpuSockets: number;
+  cpuCores: number;
+  productName: string;
+  productVersion: string;
+  networking: {
+    vNICs: {
+      key: string;
+      linkSpeed: number;
+    }[];
+    pNICs: {
+      key: string;
+      portGroup: string;
+      dPortGroup: string;
+      ipAddress: string;
+      mtu: number;
+    }[];
+    portGroups: {
+      key: string;
+      name: string;
+      vSwitch: string;
+    }[];
+    switches: {
+      key: string;
+      name: string;
+      portGroups: string[];
+      pNICs: string[];
+    }[];
+  };
+  networks: IVMwareObjRef[];
+  datastores: IVMwareObjRef[];
+  vms: IVMwareObjRef[];
+  networkAdapters: IHostNetworkAdapter[];
+}

--- a/src/app/queries/types/index.ts
+++ b/src/app/queries/types/index.ts
@@ -2,6 +2,7 @@ export * from './common.types';
 export * from './mappings.types';
 export * from './plans.types';
 export * from './providers.types';
+export * from './hosts.types';
 export * from './networks.types';
 export * from './datastores.types';
 export * from './storageClasses.types';

--- a/src/app/queries/types/providers.types.ts
+++ b/src/app/queries/types/providers.types.ts
@@ -59,21 +59,6 @@ export interface IOpenShiftProvider extends ICommonProvider {
 
 export type Provider = IVMwareProvider | IOpenShiftProvider;
 
-// TODO this structure is speculative. Check with Jeff.
-export interface IHostNetwork {
-  name: string;
-  address: string;
-  isDefault?: boolean;
-}
-
-// TODO this structure is speculative. Check with Jeff.
-export interface IHost {
-  name: string;
-  network: IHostNetwork;
-  bandwidth: string;
-  mtu: number;
-}
-
 export interface IProvidersByType {
   [ProviderType.vsphere]: IVMwareProvider[];
   [ProviderType.openshift]: IOpenShiftProvider[];

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -64,16 +64,13 @@ export const routes: AppRouteConfig[] = [
     title: `${APP_TITLE} | Providers`,
     isProtected: true,
   },
-  /*
-  // TODO (post-beta): reintroduce this page when we resolve https://github.com/konveyor/virt-ui/issues/138
   {
     component: HostsPage,
     exact: false,
-    path: '/providers/:providerId',
+    path: '/providers/:providerName',
     title: `${APP_TITLE} | Hosts`,
     isProtected: true,
   },
-  */
   {
     component: PlansPage,
     exact: true,


### PR DESCRIPTION
Resolves #138

* Restores our disabled Hosts page linked under the VMware providers table
* Fixes existing TS types for inventory hosts, includes new networking details
* Adds new TS type for the Host CR (`IHostConfig`)
* Adds mock data for these new types
* Updates existing SelectNetworkModal to hide the credential fields if you choose to reuse provider credentials (true by default)
* Adds a `useHostConfigsQuery` to load Host CRs, correlate them with host objects and display selected networks if any
* Adds a `useConfigureHostsMutation` to handle form submission and create/patch hosts/secrets as necessary
  * Looks for existing config CRs for each selected host
  * If you're passing a new secret, looks for any existing secrets present on the existing configs, and:
    * If at least one secret exists, the first one is patched and then used for all hosts
    * If not, a new secret is created and used for all hosts
  * If you're not passing a new secret, passes `{}` for the secret on all hosts (removes any existing associated secrets)
  * For each selected host, either patches or creates a host CR depending on whether there is already a matching one
  * If any of the above fails, the mutation will fail and report the first caught error (no rollback)
* Wires up the query and mutation to the table and modal