### PR TITLE
In case description is empty

### DIFF
--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -37,7 +37,7 @@ export const getPipelineSummaryTitle = (status: IVMStatus): string => {
   if (status.started && !status.completed) {
     let title: string;
     title = status.error?.phase ? `Error - ` : '';
-    if (currentStep) {
+    if (currentStep?.description) {
       title = `${title}${[currentStep.description.replace(/\.$/, '')]}`;
     }
     return title;


### PR DESCRIPTION
Besides being more robust it also allow older migration data which doesn't have the description field yet.