### PR TITLE
Use locale for mig times and display with ellipses

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@patternfly/react-tokens": "^4.9.18",
     "axios": "^0.20.0",
     "dayjs": "^1.9.3",
+    "dayjs-ext": "^2.2.0",
     "ejs": "^3.1.5",
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -23,6 +23,7 @@ import {
   wrappable,
   expandable,
   cellWidth,
+  truncate,
 } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
 import { useSelectionState } from '@konveyor/lib-ui';
@@ -165,8 +166,8 @@ const VMMigrationDetails: React.FunctionComponent = () => {
       transforms: [sortable, wrappable],
       cellFormatters: planStarted ? [expandable] : [],
     },
-    { title: 'Start time', transforms: [sortable] },
-    { title: 'End time', transforms: [sortable] },
+    { title: 'Start time', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'End time', transforms: [sortable], cellTransforms: [truncate] },
     { title: 'Data copied', transforms: [sortable] },
     {
       title: 'Status',

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -1,11 +1,13 @@
 import dayjs from 'dayjs';
 import advancedFormat from 'dayjs-ext/plugin/advancedFormat';
-import timeZone from 'dayjs-ext/plugin/timeZone';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 import { StatusCategoryType, PlanStatusAPIType, StepType } from '@app/common/constants';
 import { IStatusCondition, IStep, IVMStatus } from '@app/queries/types';
 
+dayjs.extend(utc);
+dayjs.extend(timezone);
 dayjs.extend(advancedFormat);
-dayjs.extend(timeZone);
 
 export const hasCondition = (conditions: IStatusCondition[], type: string): boolean => {
   return !!conditions.find((condition) => condition.type === type);

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
+import advancedFormat from 'dayjs-ext/plugin/advancedFormat';
 import timeZone from 'dayjs-ext/plugin/timeZone';
 import { StatusCategoryType, PlanStatusAPIType, StepType } from '@app/common/constants';
 import { IStatusCondition, IStep, IVMStatus } from '@app/queries/types';
 
+dayjs.extend(advancedFormat);
 dayjs.extend(timeZone);
 
 export const hasCondition = (conditions: IStatusCondition[], type: string): boolean => {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import advancedFormat from 'dayjs-ext/plugin/advancedFormat';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 import { StatusCategoryType, PlanStatusAPIType, StepType } from '@app/common/constants';

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -47,9 +47,8 @@ export const findCurrentStep = (
   return { currentStep, currentStepIndex };
 };
 
-export const formatTimestamp = (timestamp?: string): string => {
-  return timestamp ? new Date(timestamp).toString() : '';
-};
+export const formatTimestamp = (timestamp?: string): string =>
+  timestamp ? new Date(timestamp).toString() : '';
 
 const padNum = (num: number) => (num < 10 ? `0${num}` : `${num}`);
 

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -47,8 +47,9 @@ export const findCurrentStep = (
   return { currentStep, currentStepIndex };
 };
 
-export const formatTimestamp = (timestamp?: string): string =>
-  timestamp ? dayjs(timestamp).format('DD MMM YYYY, HH:mm:ss') : '';
+export const formatTimestamp = (timestamp?: string): string => {
+  return timestamp ? new Date(timestamp).toString() : '';
+};
 
 const padNum = (num: number) => (num < 10 ? `0${num}` : `${num}`);
 

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -1,6 +1,9 @@
 import dayjs from 'dayjs';
+import timeZone from 'dayjs-ext/plugin/timeZone';
 import { StatusCategoryType, PlanStatusAPIType, StepType } from '@app/common/constants';
 import { IStatusCondition, IStep, IVMStatus } from '@app/queries/types';
+
+dayjs.extend(timeZone);
 
 export const hasCondition = (conditions: IStatusCondition[], type: string): boolean => {
   return !!conditions.find((condition) => condition.type === type);
@@ -48,7 +51,7 @@ export const findCurrentStep = (
 };
 
 export const formatTimestamp = (timestamp?: string): string =>
-  timestamp ? new Date(timestamp).toString() : '';
+  timestamp ? dayjs(timestamp).format('DD MMM YYYY, HH:mm:ss z') : '';
 
 const padNum = (num: number) => (num < 10 ? `0${num}` : `${num}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,9 +2776,9 @@ dayjs-ext@^2.2.0:
     timezone-support "^1.8.0"
 
 dayjs@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.3.tgz#b7f94b22ad2a136a4ca02a01ab68ae893fe1a268"
-  integrity sha512-V+1SyIvkS+HmNbN1G7A9+ERbFTV9KTXu6Oor98v2xHmzzpp52OIJhQuJSTywWuBY5pyAEmlwbCi1Me87n/SLOw==
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.6.tgz#6f0c77d76ac1ff63720dd1197e5cb87b67943d70"
+  integrity sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
 commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -2761,6 +2766,14 @@ date-fns@^2.0.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
+dayjs-ext@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/dayjs-ext/-/dayjs-ext-2.2.0.tgz#2d1ed1e2a8dccc260122d4685e8422062edc5dbb"
+  integrity sha512-n7u711rSmAOPcx1xqj2WUSU/1PbWEst1VC/FeIQsC/ULQLNVlAUwYwRc8D1CdTWqZgliw/SVcox+xNyQl9Q4IA==
+  dependencies:
+    fast-plural-rules "^0.0.1"
+    timezone-support "^1.8.0"
 
 dayjs@^1.9.3:
   version "1.9.3"
@@ -3670,6 +3683,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-plural-rules@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/fast-plural-rules/-/fast-plural-rules-0.0.1.tgz#7032c8afa979e6dc65a452f0ef5b4ef31eca763b"
+  integrity sha512-0Cxx7LaH7+dNJEBozlisCxqaN5g68VTFT9PyLeFGBHmkPnQ3e46zss+r8pRC94KpzPlitL6m33GVdbMIDiUgqg==
 
 fastq@^1.6.0:
   version "1.8.0"
@@ -8714,6 +8732,13 @@ timers-browserify@^2.0.4:
   integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+timezone-support@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-1.8.1.tgz#0a8c04d0614be6fccdd2280aaad5072fa5d31e5f"
+  integrity sha512-+pKzxoUe4PZXaQcswceJlA+69oRyyu1uivnYKdpsC7eGzZiuvTLbU4WYPqTKslEsoSvjN8k/u/6qNfGikBB/wA==
+  dependencies:
+    commander "2.19.0"
 
 timsort@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Replaces `formatTimeStamp()` to use Date automated conversion to locale.

![times-tz](https://user-images.githubusercontent.com/1901741/100758661-0c82d300-33f0-11eb-8760-f4210bce8ccb.png)

Resolves https://github.com/konveyor/virt-ui/issues/185