### PR TITLE
Plan wizard review: Source, target providers, move selected VMs and add popover with VMs list

### DIFF
--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -56,6 +56,8 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         ) : null}
         <GridItem md={3}>Target namespace</GridItem>
         <GridItem md={9}>{forms.general.values.targetNamespace}</GridItem>
+        <GridItem md={3}>Selected VMs</GridItem>
+        <GridItem md={9}>{forms.selectVMs.values.selectedVMs.length}</GridItem>
         <GridItem md={3}>Network mapping</GridItem>
         <GridItem md={9}>
           <MappingDetailView mappingType={MappingType.Network} mapping={networkMapping} />
@@ -64,8 +66,6 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={9}>
           <MappingDetailView mappingType={MappingType.Storage} mapping={storageMapping} />
         </GridItem>
-        <GridItem md={3}>Selected VMs</GridItem>
-        <GridItem md={9}>{forms.selectVMs.values.selectedVMs.length}</GridItem>
       </Grid>
       <MutationStatus
         results={[

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { TextContent, Text, Grid, GridItem, Form } from '@patternfly/react-core';
+import {
+  TextContent,
+  Text,
+  Grid,
+  GridItem,
+  Form,
+  Popover,
+  Button,
+  List,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
 import MappingDetailView from '@app/Mappings/components/MappingDetailView';
@@ -57,7 +66,22 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={3}>Target namespace</GridItem>
         <GridItem md={9}>{forms.general.values.targetNamespace}</GridItem>
         <GridItem md={3}>Selected VMs</GridItem>
-        <GridItem md={9}>{forms.selectVMs.values.selectedVMs.length}</GridItem>
+        <GridItem md={9}>
+          <Popover
+            headerContent={<div>Selected VMs</div>}
+            bodyContent={
+              <List>
+                {forms.selectVMs.values.selectedVMs.map((vm, index) => (
+                  <li key={index}>{vm.name}</li>
+                ))}
+              </List>
+            }
+          >
+            <Button variant="link" isInline>
+              {forms.selectVMs.values.selectedVMs.length}
+            </Button>
+          </Popover>
+        </GridItem>
         <GridItem md={3}>Network mapping</GridItem>
         <GridItem md={9}>
           <MappingDetailView mappingType={MappingType.Network} mapping={networkMapping} />

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -63,6 +63,10 @@ const Review: React.FunctionComponent<IReviewProps> = ({
             <GridItem md={9}>{forms.general.values.planDescription}</GridItem>
           </>
         ) : null}
+        <GridItem md={3}>Source provider</GridItem>
+        <GridItem md={9}>{forms.general.values.sourceProvider?.name}</GridItem>
+        <GridItem md={3}>Target provider</GridItem>
+        <GridItem md={9}>{forms.general.values.targetProvider?.name}</GridItem>
         <GridItem md={3}>Target namespace</GridItem>
         <GridItem md={9}>{forms.general.values.targetNamespace}</GridItem>
         <GridItem md={3}>Selected VMs</GridItem>


### PR DESCRIPTION
The Plan wizard review contains following changes:
- Moves selected-VMs up.
- Adds source and target providers
- Selected VMs is shown as link with the list of VMs using a Popover.

Resolves https://github.com/konveyor/virt-ui/issues/220, resolves https://github.com/konveyor/virt-ui/issues/221, resolves https://github.com/konveyor/virt-ui/issues/222

![reviewproviders](https://user-images.githubusercontent.com/1901741/99987457-cb1b7380-2db0-11eb-9047-a4f1f614a3c3.png)

![selectedvmspopover](https://user-images.githubusercontent.com/1901741/99987579-eedeb980-2db0-11eb-8285-8a67bb6cccee.png)
