### PR TITLE
VM Concern severity: Removes Info not avail in backend and uses select filter in SelectVMs page

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -81,11 +81,16 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
     {
       key: 'migrationAnalysis',
       title: 'Migration analysis',
-      type: FilterType.search,
-      placeholderText: 'Filter by migration analysis status ...',
+      type: FilterType.select,
+      selectOptions: [
+        { key: 'Ok', value: 'Ok' },
+        { key: 'Advisory', value: 'Advisory' },
+        { key: 'Warning', value: 'Warning' },
+        { key: 'Critical', value: 'Critical' },
+      ],
       getItemValue: (item) => {
         const worstConcern = getMostSevereVMConcern(item);
-        return worstConcern ? worstConcern.severity : '';
+        return worstConcern ? worstConcern.severity : 'Ok';
       },
     },
     {

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -21,7 +21,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
     <>
       Conditions have been identified that make this VM a <strong>moderate risk</strong> to migrate.
     </>
-  ) : worstConcern.severity === 'Advisory' || worstConcern.severity === 'Info' ? (
+  ) : worstConcern.severity === 'Advisory' ? (
     <>Conditions have been identified, but they do not affect the migration risk.</>
   ) : null;
   if (vm.revisionAnalyzed < vm.revision) {

--- a/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -25,9 +25,6 @@ const VMConcernsIcon: React.FunctionComponent<IVMConcernsIconProps> = ({
   if (worstConcern.severity === 'Warning') {
     return <StatusIcon status={StatusType.Warning} label="Warning" />;
   }
-  if (worstConcern.severity === 'Info') {
-    return <StatusIcon status={StatusType.Info} label="Info" />;
-  }
   if (worstConcern.severity === 'Advisory') {
     return (
       <>

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -271,12 +271,10 @@ export const getMostSevereVMConcern = (vm: IVMwareVM): IVMwareVMConcern | null =
   }
   const critical = vm.concerns.find((concern) => concern.severity === 'Critical');
   const warning = vm.concerns.find((concern) => concern.severity === 'Warning');
-  const info = vm.concerns.find(
-    (concern) => concern.severity === 'Info' || concern.severity === 'Advisory'
-  );
+  const advisory = vm.concerns.find((concern) => concern.severity === 'Advisory');
   if (critical) return critical;
   if (warning) return warning;
-  if (info) return info;
+  if (advisory) return advisory;
   // Default to warning if an unexpected severity is found
   return { severity: 'Warning', name: 'Unknown' };
 };

--- a/src/app/queries/mocks/vms.mock.ts
+++ b/src/app/queries/mocks/vms.mock.ts
@@ -62,7 +62,7 @@ MOCK_VMWARE_VMS = [
         datastore: { kind: 'Datastore', id: '2' },
       },
     ],
-    concerns: [{ name: 'Example', severity: 'Warning' }],
+    concerns: [{ name: 'Example', severity: 'Advisory' }],
     revisionAnalyzed: 1,
   },
   {
@@ -93,7 +93,7 @@ MOCK_VMWARE_VMS = [
         datastore: { kind: 'Datastore', id: '1' },
       },
     ],
-    concerns: [{ name: 'Example', severity: 'Warning' }],
+    concerns: [{ name: 'Example', severity: 'Critical' }],
     revisionAnalyzed: 1,
   },
   {
@@ -156,7 +156,7 @@ MOCK_VMWARE_VMS = [
         datastore: { kind: 'Datastore', id: '3' },
       },
     ],
-    concerns: [{ name: 'Example', severity: 'Warning' }],
+    concerns: [],
     revisionAnalyzed: 1,
   },
 ];

--- a/src/app/queries/types/vms.types.ts
+++ b/src/app/queries/types/vms.types.ts
@@ -7,7 +7,7 @@ export interface IVMwareVMDisk {
 
 export interface IVMwareVMConcern {
   name: string;
-  severity: 'Warning' | 'Critical' | 'Advisory' | 'Info';
+  severity: 'Warning' | 'Critical' | 'Advisory';
 }
 
 export interface IVMwareVM {


### PR DESCRIPTION
- Remove VM Concern severity Info not avail in backend
- Select VMs now uses select filter for migration analytics

Resolves https://github.com/konveyor/virt-ui/issues/126, resolves https://github.com/konveyor/virt-ui/issues/219