### PR TITLE
Cascade delete migrations when removing migration plan

### DIFF
--- a/src/app/queries/migrations.ts
+++ b/src/app/queries/migrations.ts
@@ -24,6 +24,14 @@ export const useCreateMigrationMutation = (
         metadata: {
           name: `${plan.metadata.name}-${Date.now()}`,
           namespace: VIRT_META.namespace,
+          ownerReferences: [
+            {
+              apiVersion: plan.apiVersion,
+              kind: plan.kind,
+              name: plan.metadata.name,
+              uid: plan.metadata.uid,
+            },
+          ],
         },
         spec: {
           plan: nameAndNamespace(plan.metadata),

--- a/src/app/queries/types/common.types.ts
+++ b/src/app/queries/types/common.types.ts
@@ -4,7 +4,7 @@ export interface IMetaTypeMeta {
   kind: string;
 }
 
-interface objectReference {
+interface IObjectReference {
   apiVersion: string;
   kind: string;
   name: string;
@@ -23,7 +23,7 @@ export interface IMetaObjectMeta {
   annotations?: {
     'kubectl.kubernetes.io/last-applied-configuration': string; // JSON
   };
-  ownerReferences?: objectReference[];
+  ownerReferences?: IObjectReference[];
 }
 
 export interface ICR extends IMetaTypeMeta {

--- a/src/app/queries/types/common.types.ts
+++ b/src/app/queries/types/common.types.ts
@@ -4,6 +4,13 @@ export interface IMetaTypeMeta {
   kind: string;
 }
 
+interface objectReference {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  uid: string | undefined;
+}
+
 // TODO: lib-ui candidate
 export interface IMetaObjectMeta {
   name: string;
@@ -16,6 +23,7 @@ export interface IMetaObjectMeta {
   annotations?: {
     'kubectl.kubernetes.io/last-applied-configuration': string; // JSON
   };
+  ownerReferences?: objectReference[];
 }
 
 export interface ICR extends IMetaTypeMeta {


### PR DESCRIPTION
Note: This issue was initially targeted for post Beta.

Resolves https://github.com/konveyor/virt-ui/issues/190