### PR TITLE
Properly remove secret when configuring a host with 'reuse creds' checked

### DIFF
--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -61,7 +61,7 @@ export const getExistingHostConfigs = (
   selectedHosts: IHost[],
   allHostConfigs: IHostConfig[],
   provider: IVMwareProvider
-) =>
+): (IHostConfig | undefined)[] =>
   selectedHosts.map((host) =>
     allHostConfigs.find((config) => configMatchesHost(config, host, provider))
   );
@@ -107,7 +107,7 @@ const generateHostConfig = (
     id: host.id,
     ipAddress: values.selectedNetworkAdapter?.ipAddress || '',
     provider: nameAndNamespace(provider),
-    secret: secretRef || {},
+    secret: secretRef || null,
   },
 });
 

--- a/src/app/queries/types/hosts.types.ts
+++ b/src/app/queries/types/hosts.types.ts
@@ -56,7 +56,7 @@ export interface IHostConfig extends ICR {
     id: string;
     ipAddress: string;
     provider: INameNamespaceRef;
-    secret?: Partial<INameNamespaceRef>;
+    secret?: INameNamespaceRef | null;
     thumbprint?: string;
   };
   status?: {


### PR DESCRIPTION
Resolves #279